### PR TITLE
feat: add `LibSafeRange`

### DIFF
--- a/src/math/LibSafeRange.sol
+++ b/src/math/LibSafeRange.sol
@@ -1,0 +1,20 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library LibSafeRange {
+  function add(uint256 a, uint256 b) internal pure returns (uint256 c) {
+    unchecked {
+      c = a + b;
+      if (c < a) return type(uint256).max;
+    }
+  }
+
+  /**
+   * @dev Returns value of a + b; in case result is larger than upperbound, upperbound is returned.
+   */
+  function addWithUpperbound(uint256 a, uint256 b, uint256 ceil) internal pure returns (uint256 c) {
+    if (a > ceil || b > ceil) return ceil;
+    c = add(a, b);
+    if (c > ceil) return ceil;
+  }
+}


### PR DESCRIPTION
### Description
This PR adds `LibSafeRange` which allows ceiling result to specific upper bound.
### Checklist
-   [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
-   [x] The box that allows repo maintainers to update this PR is checked
-   [x] I tested locally to make sure this feature/fix works
