### PR TITLE
chore: fix lib native transfer test

### DIFF
--- a/test/transfers/LibNativeTransfer.t.sol
+++ b/test/transfers/LibNativeTransfer.t.sol
@@ -25,7 +25,7 @@ contract LibNativeTransferTest is Test {
     // Transferring to msg.sender can fail because it's possible to overflow their ETH balance as it begins non-zero.
     if (recipient.code.length > 0 || uint256(uint160(recipient)) <= 18 || recipient == msg.sender) return;
 
-    amount = bound(amount, 0, address(this).balance);
+    amount = _bound(amount, 0, address(this).balance);
     LibNativeTransfer.transfer(recipient, amount, gas);
 
     assertEq(recipient.balance, amount);


### PR DESCRIPTION
### Description
This PR fix console log error when using `forge-std:bound` on `LibNativeTransferTest`
### Checklist
-   [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
-   [x] The box that allows repo maintainers to update this PR is checked
-   [x] I tested locally to make sure this feature/fix works
