### PR TITLE
feat(LibEventRange): add `LibEventRange` lib

### DIFF
--- a/logs/contract-code-sizes.log
+++ b/logs/contract-code-sizes.log
@@ -1,27 +1,16 @@
-| Contract                  | Size (kB) | Margin (kB) |
-|---------------------------|-----------|-------------|
-| LibErrorHandler           | 0.086     | 24.49       |
-| LibNativeTransfer         | 0.086     | 24.49       |
-| LibSafeRange              | 0.086     | 24.49       |
-| Math                      | 0.086     | 24.49       |
-| MockERC20                 | 3.704     | 20.872      |
-| MockERC721                | 3.964     | 20.612      |
-| Panic                     | 0.086     | 24.49       |
-| RONTransferHelper         | 0.086     | 24.49       |
-| RONTransferHelperExtended | 0.086     | 24.49       |
-| SafeCast                  | 0.086     | 24.49       |
-| SignedMath                | 0.086     | 24.49       |
-| StdStyle                  | 0.086     | 24.49       |
-| Strings                   | 0.086     | 24.49       |
-| TransferFromHelper        | 0.086     | 24.49       |
-| TransferHelper            | 0.086     | 24.49       |
-| console                   | 0.086     | 24.49       |
-| console2                  | 0.086     | 24.49       |
-| safeconsole               | 0.086     | 24.49       |
-| stdError                  | 0.592     | 23.984      |
-| stdJson                   | 0.086     | 24.49       |
-| stdMath                   | 0.086     | 24.49       |
-| stdStorage                | 0.086     | 24.49       |
-| stdStorageSafe            | 0.086     | 24.49       |
-| stdToml                   | 0.086     | 24.49       |
+| Contract                  | Size (B) | Margin (B) |
+|---------------------------|----------|------------|
+| LibErrorHandler           |       86 |     24,490 |
+| LibEventRange             |       86 |     24,490 |
+| LibNativeTransfer         |       86 |     24,490 |
+| LibSafeRange              |       86 |     24,490 |
+| Math                      |       86 |     24,490 |
+| Panic                     |       86 |     24,490 |
+| RONTransferHelper         |       86 |     24,490 |
+| RONTransferHelperExtended |       86 |     24,490 |
+| SafeCast                  |       86 |     24,490 |
+| SignedMath                |       86 |     24,490 |
+| Strings                   |       86 |     24,490 |
+| TransferFromHelper        |       86 |     24,490 |
+| TransferHelper            |       86 |     24,490 |
 

--- a/src/LibEventRange.sol
+++ b/src/LibEventRange.sol
@@ -1,0 +1,42 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+struct EventRange {
+  // uint40 is enough to represent the timestamp until year 36812
+  uint40 startedAt;
+  uint40 endedAt;
+  /// @dev Reserved space for future upgrades
+  uint176 __reserved;
+}
+
+using LibEventRange for EventRange global;
+
+library LibEventRange {
+  /**
+   * @dev Checks whether the event range is valid.
+   */
+  function valid(EventRange memory range) internal pure returns (bool) {
+    return range.startedAt <= range.endedAt;
+  }
+
+  /**
+   * @dev Returns whether the current range is not yet started.
+   */
+  function isNotYetStarted(EventRange memory range) internal view returns (bool) {
+    return block.timestamp < range.startedAt;
+  }
+
+  /**
+   * @dev Returns whether the current range is ended or not.
+   */
+  function isEnded(EventRange memory range) internal view returns (bool) {
+    return range.endedAt <= block.timestamp;
+  }
+
+  /**
+   * @dev Returns whether the current block is in period.
+   */
+  function isInPeriod(EventRange memory range) internal view returns (bool) {
+    return range.startedAt <= block.timestamp && block.timestamp < range.endedAt;
+  }
+}


### PR DESCRIPTION
### Description
This PR adds `LibEventRange` library.
### Checklist

-   [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
-   [x] The box that allows repo maintainers to update this PR is checked
-   [x] I tested locally to make sure this feature/fix works
