### PR TITLE
feat(LibChainlinkPriceFeed): add LibChainlinkPriceFeed and unit tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -11,6 +11,7 @@ evm_version = 'istanbul'
 use_literal_content = true
 extra_output = ["devdoc", "userdoc", "storagelayout"]
 fs_permissions = [{ access = "read-write", path = "./" }]
+allow_internal_expect_revert = true
 
 [fmt]
 tab_width = 2
@@ -35,4 +36,23 @@ forge-std = { version = "1.8.2" }
 chainlink = { version = "2.21.0", url = "https://github.com/smartcontractkit/chainlink/archive/refs/tags/v2.21.0.zip" }
 openzeppelin = { version = "4.9.6", url = "https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v4.9.6.zip" }
 pyth = { version = "2.2.0", url = "https://github.com/pyth-network/pyth-sdk-solidity/archive/refs/tags/v2.2.0.zip" }
-solady = { version = "0.1.12", url = "https://github.com/Vectorized/solady/archive/refs/tags/v0.1.12.zip" }
+
+[soldeer]
+# whether soldeer manages remappings
+remappings_generate = false
+
+# whether soldeer re-generates all remappings when installing, updating or uninstalling deps
+remappings_regenerate = false
+
+# whether to suffix the remapping with the version: `name-a.b.c`
+remappings_version = true
+
+# a prefix to add to the remappings ("@" would give `@name`)
+remappings_prefix = "@"
+
+# where to store the remappings ("txt" for `remappings.txt` or "config" for `foundry.toml`)
+# ignored when `soldeer.toml` is used as config (uses `remappings.txt`)
+remappings_location = "txt"
+
+# whether to install sub-dependencies or not. If true this wil install the dependencies of dependencies 1 level down.
+recursive_deps = true

--- a/foundry.toml
+++ b/foundry.toml
@@ -20,7 +20,7 @@ bracket_spacing = true
 [rpc_endpoints]
 localhost = "http://localhost:8545"
 ethereum = "https://eth.llamarpc.com"
-ronin-mainnet = "https://api.roninchain.com/rpc"
+ronin-mainnet = "https://api-archived.roninchain.com/rpc"
 goerli = "https://ethereum-goerli.publicnode.com"
 ronin-testnet = "https://saigon-archive.roninchain.com/rpc"
 
@@ -32,4 +32,7 @@ runs = 256
 
 [dependencies]
 forge-std = { version = "1.8.2" }
-"@openzeppelin-contracts" = { version = "4.9.6" }
+chainlink = { version = "2.21.0", url = "https://github.com/smartcontractkit/chainlink/archive/refs/tags/v2.21.0.zip" }
+openzeppelin = { version = "4.9.6", url = "https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v4.9.6.zip" }
+pyth = { version = "2.2.0", url = "https://github.com/pyth-network/pyth-sdk-solidity/archive/refs/tags/v2.2.0.zip" }
+solady = { version = "0.1.12", url = "https://github.com/Vectorized/solady/archive/refs/tags/v0.1.12.zip" }

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,0 @@
-pyth-2.2.0/=dependencies/pyth-2.2.0/
-solady-0.1.12/=dependencies/solady-0.1.12/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,2 @@
-@forge-std-1.8.2=dependencies/forge-std-1.8.2
-@openzeppelin-contracts-4.9.6=dependencies/@openzeppelin-contracts-4.9.6
+pyth-2.2.0/=dependencies/pyth-2.2.0/
+solady-0.1.12/=dependencies/solady-0.1.12/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -3,7 +3,7 @@ name = "chainlink"
 version = "2.21.0"
 url = "https://github.com/smartcontractkit/chainlink/archive/refs/tags/v2.21.0.zip"
 checksum = "436fb27dba983312c9af978374f056d5e83033f951d9236235ed799267cd0a02"
-integrity = "a96ab445a5756b7ba30b993804409d49c37f0145d50417875c04aafff2833aad"
+integrity = "52944737dd1c3d6f05390541ecffdea3c3802fc0712916e40cf4bd314574303a"
 
 [[dependencies]]
 name = "forge-std"
@@ -17,7 +17,7 @@ name = "openzeppelin"
 version = "4.9.6"
 url = "https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v4.9.6.zip"
 checksum = "7af0307b0ad8560aa09405da10bd705fd189b544597695b2c3046b15ce637e47"
-integrity = "0c15334521639077e01a73f21dbbfa1ce5ae6061a9e6c591ce93607abbffbc38"
+integrity = "559f038c60d5352d61332f7b4e81d4e021b3d4b6688fd384d12a23aaf2649395"
 
 [[dependencies]]
 name = "pyth"
@@ -25,10 +25,3 @@ version = "2.2.0"
 url = "https://github.com/pyth-network/pyth-sdk-solidity/archive/refs/tags/v2.2.0.zip"
 checksum = "71431ac3fe4e61ce2b8abd649d3e741277ca4dba287c2a4291d040190b8fb8da"
 integrity = "845f9e662935eb347e9189da9b156f0062bcab1d372c7397777dbda609776a5c"
-
-[[dependencies]]
-name = "solady"
-version = "0.1.12"
-url = "https://github.com/Vectorized/solady/archive/refs/tags/v0.1.12.zip"
-checksum = "6646be228dc0d95cbcd4b937f0a805a2e1e13c60e9bb7ed927eaa18baf8d06a2"
-integrity = "c2d5cc3d6374e52ea0aa3a7a4a82871084cdb9df12c89787fe0e777177e5f52d"

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,12 +1,41 @@
+[[dependencies]]
+name = "@openzeppelin-contracts"
+version = "4.9.6"
+url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/4_9_6_14-03-2024_06:11:55_contracts.zip"
+checksum = "57f2cae4b45b91b0847e58c36ea70aee0fb3212cc09b47279627f0764f87e5ee"
+integrity = "861134d6a3739362ce5ef6541538e23ca1df10ec47151f105057bea0bb710330"
+
+[[dependencies]]
+name = "chainlink"
+version = "2.21.0"
+url = "https://github.com/smartcontractkit/chainlink/archive/refs/tags/v2.21.0.zip"
+checksum = "436fb27dba983312c9af978374f056d5e83033f951d9236235ed799267cd0a02"
+integrity = "52944737dd1c3d6f05390541ecffdea3c3802fc0712916e40cf4bd314574303a"
 
 [[dependencies]]
 name = "forge-std"
 version = "1.8.2"
-source = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_8_2_19-05-2024_18:52:07_forge-std-1.8.2.zip"
+url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_8_2_19-05-2024_18:52:07_forge-std-1.8.2.zip"
 checksum = "88a37e1d79f60b8aad08c7bd50a7a5ef973fc172b1495028d0725a17f5a4976c"
+integrity = "7db36e30b7e5ff6bd2a38ee5d634d811ed98fd7c684785f937fea3ac3df37111"
 
 [[dependencies]]
-name = "@openzeppelin-contracts"
+name = "openzeppelin"
 version = "4.9.6"
-source = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/4_9_6_14-03-2024_06:11:55_contracts.zip"
-checksum = "57f2cae4b45b91b0847e58c36ea70aee0fb3212cc09b47279627f0764f87e5ee"
+url = "https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v4.9.6.zip"
+checksum = "7af0307b0ad8560aa09405da10bd705fd189b544597695b2c3046b15ce637e47"
+integrity = "559f038c60d5352d61332f7b4e81d4e021b3d4b6688fd384d12a23aaf2649395"
+
+[[dependencies]]
+name = "pyth"
+version = "2.2.0"
+url = "https://github.com/pyth-network/pyth-sdk-solidity/archive/refs/tags/v2.2.0.zip"
+checksum = "71431ac3fe4e61ce2b8abd649d3e741277ca4dba287c2a4291d040190b8fb8da"
+integrity = "845f9e662935eb347e9189da9b156f0062bcab1d372c7397777dbda609776a5c"
+
+[[dependencies]]
+name = "solady"
+version = "0.1.12"
+url = "https://github.com/Vectorized/solady/archive/refs/tags/v0.1.12.zip"
+checksum = "6646be228dc0d95cbcd4b937f0a805a2e1e13c60e9bb7ed927eaa18baf8d06a2"
+integrity = "02ceeaa53302c5e690ffd588d8b6658977acbe746eb32ad57e91a246cc071176"

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,16 +1,9 @@
 [[dependencies]]
-name = "@openzeppelin-contracts"
-version = "4.9.6"
-url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/4_9_6_14-03-2024_06:11:55_contracts.zip"
-checksum = "57f2cae4b45b91b0847e58c36ea70aee0fb3212cc09b47279627f0764f87e5ee"
-integrity = "861134d6a3739362ce5ef6541538e23ca1df10ec47151f105057bea0bb710330"
-
-[[dependencies]]
 name = "chainlink"
 version = "2.21.0"
 url = "https://github.com/smartcontractkit/chainlink/archive/refs/tags/v2.21.0.zip"
 checksum = "436fb27dba983312c9af978374f056d5e83033f951d9236235ed799267cd0a02"
-integrity = "52944737dd1c3d6f05390541ecffdea3c3802fc0712916e40cf4bd314574303a"
+integrity = "a96ab445a5756b7ba30b993804409d49c37f0145d50417875c04aafff2833aad"
 
 [[dependencies]]
 name = "forge-std"
@@ -24,7 +17,7 @@ name = "openzeppelin"
 version = "4.9.6"
 url = "https://github.com/OpenZeppelin/openzeppelin-contracts/archive/refs/tags/v4.9.6.zip"
 checksum = "7af0307b0ad8560aa09405da10bd705fd189b544597695b2c3046b15ce637e47"
-integrity = "559f038c60d5352d61332f7b4e81d4e021b3d4b6688fd384d12a23aaf2649395"
+integrity = "0c15334521639077e01a73f21dbbfa1ce5ae6061a9e6c591ce93607abbffbc38"
 
 [[dependencies]]
 name = "pyth"
@@ -38,4 +31,4 @@ name = "solady"
 version = "0.1.12"
 url = "https://github.com/Vectorized/solady/archive/refs/tags/v0.1.12.zip"
 checksum = "6646be228dc0d95cbcd4b937f0a805a2e1e13c60e9bb7ed927eaa18baf8d06a2"
-integrity = "02ceeaa53302c5e690ffd588d8b6658977acbe746eb32ad57e91a246cc071176"
+integrity = "c2d5cc3d6374e52ea0aa3a7a4a82871084cdb9df12c89787fe0e777177e5f52d"

--- a/src/LibErrorHandler.sol
+++ b/src/LibErrorHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.0;
 
 library LibErrorHandler {
   /// @dev Reserves error definition to upload to signature database.

--- a/src/legacy/transfers/RONTransferHelper.sol
+++ b/src/legacy/transfers/RONTransferHelper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Strings } from "../../../dependencies/@openzeppelin-contracts-4.9.6/utils/Strings.sol";
+import { Strings } from "../../../dependencies/openzeppelin-4.9.6/contracts/utils/Strings.sol";
 
 /**
  * @title RONTransferHelper

--- a/src/legacy/transfers/TransferFromHelper.sol
+++ b/src/legacy/transfers/TransferFromHelper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Strings } from "../../../dependencies/@openzeppelin-contracts-4.9.6/utils/Strings.sol";
+import { Strings } from "../../../dependencies/openzeppelin-4.9.6/contracts/utils/Strings.sol";
 
 /**
  * @title TransferFromHelper

--- a/src/legacy/transfers/TransferHelper.sol
+++ b/src/legacy/transfers/TransferHelper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Strings } from "../../../dependencies/@openzeppelin-contracts-4.9.6/utils/Strings.sol";
+import { Strings } from "../../../dependencies/openzeppelin-4.9.6/contracts/utils/Strings.sol";
 
 /**
  * @title TransferHelper

--- a/src/math/LibPowMath.sol
+++ b/src/math/LibPowMath.sol
@@ -1,0 +1,130 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { SafeMath } from "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/SafeMath.sol";
+import { Math } from "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/Math.sol";
+
+library LibPowMath {
+  using Math for uint256;
+  using SafeMath for uint256;
+
+  /**
+   * @dev Negative exponent n for x*10^n.
+   */
+  function exp10(uint256 x, int32 n) internal pure returns (uint256) {
+    if (n < 0) {
+      return x / 10 ** uint32(-n);
+    } else if (n > 0) {
+      return x * 10 ** uint32(n);
+    } else {
+      return x;
+    }
+  }
+
+  /**
+   * @dev Calculates floor(x * (y / d)**n) with full precision.
+   */
+  function mulDiv(uint256 x, uint256 y, uint256 d, uint16 n) internal pure returns (uint256 r) {
+    unchecked {
+      if (y == d || n == 0) return x;
+      r = x;
+
+      bool ok;
+      uint256 r_;
+      uint16 nd_;
+
+      {
+        uint16 ye = uint16(Math.min(n, findMaxExponent(y)));
+        while (ye > 0) {
+          (ok, r_) = r.tryMul(y ** ye);
+          if (ok) {
+            r = r_;
+            n -= ye;
+            nd_ += ye;
+          }
+          ye = uint16(Math.min(ye / 2, n));
+        }
+      }
+
+      while (n > 0) {
+        (ok, r_) = r.tryMul(y);
+        if (ok) {
+          r = r_;
+          n--;
+          nd_++;
+        } else if (nd_ > 0) {
+          r /= d;
+          nd_--;
+        } else {
+          r = r.mulDiv(y, d);
+          n--;
+        }
+      }
+
+      uint16 de = findMaxExponent(d);
+      while (nd_ > 0) {
+        uint16 e = uint16(Math.min(de, nd_));
+        r /= d ** e;
+        nd_ -= e;
+      }
+    }
+  }
+
+  /**
+   * @dev Calculates floor(x * (y / d)**n) with low precision.
+   */
+  function mulDivLowPrecision(uint256 x, uint256 y, uint256 d, uint16 n) internal pure returns (uint256) {
+    return uncheckedMulDiv(x, y, d, n, findMaxExponent(Math.max(y, d)));
+  }
+
+  /**
+   * @dev Aggregated calculate multiplications.
+   * ```
+   * r = x*(y/d)^k
+   *   = \prod(x*(y/d)^{k_i}) \ where \ sum(k_i) = k
+   * ```
+   */
+  function uncheckedMulDiv(uint256 x, uint256 y, uint256 d, uint16 n, uint16 maxE) internal pure returns (uint256 r) {
+    unchecked {
+      r = x;
+      uint16 e;
+      while (n > 0) {
+        e = uint16(Math.min(n, maxE));
+        r = r.mulDiv(y ** e, d ** e);
+        n -= e;
+      }
+    }
+  }
+
+  /**
+   * @dev Returns the largest exponent `k` where, x^k <= 2^256-1
+   * Note: n = Surd[2^256-1,k]
+   *         = 10^( log2(2^256-1) / k * log10(2) )
+   */
+  function findMaxExponent(uint256 x) internal pure returns (uint16 k) {
+    if (x < 3) k = 255;
+    else if (x < 4) k = 128;
+    else if (x < 16) k = 64;
+    else if (x < 256) k = 32;
+    else if (x < 7132) k = 20;
+    else if (x < 11376) k = 19;
+    else if (x < 19113) k = 18;
+    else if (x < 34132) k = 17;
+    else if (x < 65536) k = 16;
+    else if (x < 137271) k = 15;
+    else if (x < 319558) k = 14;
+    else if (x < 847180) k = 13;
+    else if (x < 2642246) k = 12;
+    else if (x < 10134189) k = 11;
+    else if (x < 50859009) k = 10;
+    else if (x < 365284285) k = 9;
+    else if (x < 4294967296) k = 8;
+    else if (x < 102116749983) k = 7;
+    else if (x < 6981463658332) k = 6;
+    else if (x < 2586638741762875) k = 5;
+    else if (x < 18446744073709551616) k = 4;
+    else if (x < 48740834812604276470692695) k = 3;
+    else if (x < 340282366920938463463374607431768211456) k = 2;
+    else k = 1;
+  }
+}

--- a/src/price-feeds/chainlink/ChainlinkPriceFeedConsumer.sol
+++ b/src/price-feeds/chainlink/ChainlinkPriceFeedConsumer.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { ChainlinkPriceFeed } from "./LibChainlinkPriceFeed.sol";
+
+abstract contract ChainlinkPriceFeedConsumer {
+  /// @dev Value is equal to keccak256(abi.encode(uint256(keccak256("ronin.lib.storage.ChainlinkPriceFeedConsumer")) - 1)) & ~bytes32(uint256(0xff))
+  bytes32 private constant $$_PriceFeedStorageLocation =
+    0xb81636ce02fbbb9f00eddb5b6bbc4ea535be42b2bde99d5f1ee576635dbe3600;
+
+  /**
+   * @dev Updates the Chainlink price feed data.
+   */
+  function _updatePriceFeed(address aggregator, uint8 tokenInDecimal, uint8 tokenOutDecimal, uint64 maxAcceptableAge)
+    internal
+  {
+    ChainlinkPriceFeed storage $ = _getPriceFeedStorage();
+    $.set(aggregator, tokenInDecimal, tokenOutDecimal, maxAcceptableAge);
+  }
+
+  /**
+   * @dev Returns the Chainlink price feed read-only.
+   */
+  function _getPriceFeed() internal pure returns (ChainlinkPriceFeed memory priceFeed) {
+    ChainlinkPriceFeed storage $ = _getPriceFeedStorage();
+    return $;
+  }
+
+  /**
+   * @dev Returns the Chainlink price feed storage variable.
+   */
+  function _getPriceFeedStorage() private pure returns (ChainlinkPriceFeed storage $) {
+    assembly ("memory-safe") {
+      $.slot := $$_PriceFeedStorageLocation
+    }
+  }
+}

--- a/src/price-feeds/chainlink/ChainlinkPriceFeedConsumer.sol
+++ b/src/price-feeds/chainlink/ChainlinkPriceFeedConsumer.sol
@@ -8,13 +8,18 @@ abstract contract ChainlinkPriceFeedConsumer {
   bytes32 private constant $$_PriceFeedStorageLocation =
     0xb81636ce02fbbb9f00eddb5b6bbc4ea535be42b2bde99d5f1ee576635dbe3600;
 
+  /// @custom:storage-location erc7201:ronin.lib.storage.ChainlinkPriceFeedConsumer
+  struct ChainlinkPriceFeedConsumerStorage {
+    ChainlinkPriceFeed _priceFeed;
+  }
+
   /**
    * @dev Updates the Chainlink price feed data.
    */
   function _updatePriceFeed(address aggregator, uint8 tokenInDecimal, uint8 tokenOutDecimal, uint64 maxAcceptableAge)
     internal
   {
-    ChainlinkPriceFeed storage $ = _getPriceFeedStorage();
+    ChainlinkPriceFeed storage $ = _getPriceFeedStorage()._priceFeed;
     $.set(aggregator, tokenInDecimal, tokenOutDecimal, maxAcceptableAge);
   }
 
@@ -22,22 +27,22 @@ abstract contract ChainlinkPriceFeedConsumer {
    * @dev Updates the Chainlink price feed max acceptable age for querying price.
    */
   function _updateMaxAcceptableAge(uint64 maxAcceptableAge) internal {
-    ChainlinkPriceFeed storage $ = _getPriceFeedStorage();
+    ChainlinkPriceFeed storage $ = _getPriceFeedStorage()._priceFeed;
     $.setMaxAcceptableAge(maxAcceptableAge);
   }
 
   /**
    * @dev Returns the Chainlink price feed read-only.
    */
-  function _getPriceFeed() internal pure returns (ChainlinkPriceFeed memory priceFeed) {
-    ChainlinkPriceFeed storage $ = _getPriceFeedStorage();
+  function _getPriceFeed() internal view returns (ChainlinkPriceFeed memory priceFeed) {
+    ChainlinkPriceFeed storage $ = _getPriceFeedStorage()._priceFeed;
     return $;
   }
 
   /**
    * @dev Returns the Chainlink price feed storage variable.
    */
-  function _getPriceFeedStorage() private pure returns (ChainlinkPriceFeed storage $) {
+  function _getPriceFeedStorage() private pure returns (ChainlinkPriceFeedConsumerStorage storage $) {
     assembly ("memory-safe") {
       $.slot := $$_PriceFeedStorageLocation
     }

--- a/src/price-feeds/chainlink/ChainlinkPriceFeedConsumer.sol
+++ b/src/price-feeds/chainlink/ChainlinkPriceFeedConsumer.sol
@@ -19,6 +19,14 @@ abstract contract ChainlinkPriceFeedConsumer {
   }
 
   /**
+   * @dev Updates the Chainlink price feed max acceptable age for querying price.
+   */
+  function _updateMaxAcceptableAge(uint64 maxAcceptableAge) internal {
+    ChainlinkPriceFeed storage $ = _getPriceFeedStorage();
+    $.setMaxAcceptableAge(maxAcceptableAge);
+  }
+
+  /**
    * @dev Returns the Chainlink price feed read-only.
    */
   function _getPriceFeed() internal pure returns (ChainlinkPriceFeed memory priceFeed) {

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -27,6 +27,8 @@ library LibChainlinkPriceFeed {
   error LargeDecimal(uint8 decimal);
   /// @dev Thrown when the price update timestamp is older than the max acceptable age.
   error ExceededMaxAcceptableAge(uint256 latestTimestamp, uint256 maxAcceptableTimestamp);
+  /// @dev Thrown when the price is negative.
+  error PanicQuotePrice(int256 answer);
 
   /// @dev Emitted when the price feed is updated.
   event ChainlinkPriceFeedUpdated(
@@ -119,6 +121,7 @@ library LibChainlinkPriceFeed {
     if (updatedAt < block.timestamp - priceFeed._maxAcceptableAge) {
       revert ExceededMaxAcceptableAge(updatedAt, block.timestamp - priceFeed._maxAcceptableAge);
     }
+    if (answer <= 0) revert PanicQuotePrice(answer);
 
     return uint256(answer);
   }

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -18,8 +18,10 @@ using LibChainlinkPriceFeed for ChainlinkPriceFeed global;
 library LibChainlinkPriceFeed {
   using LibPowMath for uint256;
 
-  /// @dev The maximum decimal for the token.
-  /// @dev This is used to prevent overflow when scaling the price.
+  /**
+   * @dev This is used to prevent overflow when scaling the price.
+   * Reference: https://github.com/pancakeswap/pancake-smart-contracts/blob/cb079908a30328e46d42fe8cc77b9f7d38a15c2f/projects/farms-pools/contracts/SmartChef.sol#L94
+   */
   uint8 internal constant _DECIMAL_LIMIT = 30;
   /// @dev Value of log10(2**256 - 1)
   uint8 internal constant _MAX_DECIMAL = 77;

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -23,6 +23,7 @@ library LibChainlinkPriceFeed {
   /// @dev This is used to prevent overflow when scaling the price.
   uint8 internal constant _MAX_DECIMALS = 30;
 
+  /// @dev Thrown when the decimal is larger than the maximum decimal.
   error LargeDecimal(uint8 decimal);
   /// @dev Thrown when the price update timestamp is older than the max acceptable age.
   error ExceededMaxAcceptableAge(uint256 latestTimestamp, uint256 maxAcceptableTimestamp);

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -8,39 +8,56 @@ import { LibPowMath } from "../../math/LibPowMath.sol";
 
 struct ChainlinkPriceFeed {
   AggregatorV2V3Interface aggregator;
-  int32 pairDecimal;
-  int32 tokenInDecimal;
-  int32 tokenOutDecimal;
-  uint256 maxAcceptableAge;
+  uint8 pairDecimal;
+  uint8 tokenInDecimal;
+  uint8 tokenOutDecimal;
+  uint64 maxAcceptableAge;
 }
 
 using LibChainlinkPriceFeed for ChainlinkPriceFeed global;
 
 library LibChainlinkPriceFeed {
-  error QuotingPriceFailed();
-  error ExponentTooLarge(int32 expo);
-  error PositiveExponent(int32 expo);
+  using LibPowMath for uint256;
+
+  /// @dev The maximum decimal for the token.
+  /// @dev This is used to prevent overflow when scaling the price.
+  uint8 internal constant _MAX_DECIMALS = 30;
+
+  error LargeDecimal(uint8 decimal);
+  /// @dev Thrown when the price update timestamp is older than the max acceptable age.
   error ExceededMaxAcceptableAge(uint256 latestTimestamp, uint256 maxAcceptableTimestamp);
 
+  /// @dev Emitted when the price feed is updated.
   event ChainlinkPriceFeedUpdated(
     AggregatorV2V3Interface indexed aggregator,
-    int32 tokenInDecimal,
-    int32 tokenOutDecimal,
-    uint256 maxAcceptableAge,
+    uint8 tokenInDecimal,
+    uint8 tokenOutDecimal,
+    uint64 maxAcceptableAge,
     string description
   );
 
+  /**
+   * @dev Sets the price feed for a token.
+   * @param $priceFeed The Chainlink price feed storage variable.
+   * @param aggregator The address of the Chainlink aggregator.
+   * @param tokenInDecimal The decimal of token in.
+   * @param tokenOutDecimal The decimal of token out.
+   * @param maxAcceptableAge The max acceptable age for the price.
+   */
   function set(
     ChainlinkPriceFeed storage $priceFeed,
     address aggregator,
-    int32 tokenInDecimal,
-    int32 tokenOutDecimal,
-    uint256 maxAcceptableAge
+    uint8 tokenInDecimal,
+    uint8 tokenOutDecimal,
+    uint64 maxAcceptableAge
   ) internal {
+    if (tokenInDecimal > _MAX_DECIMALS) revert LargeDecimal(tokenInDecimal);
+    if (tokenOutDecimal > _MAX_DECIMALS) revert LargeDecimal(tokenOutDecimal);
+
     $priceFeed.aggregator = AggregatorV2V3Interface(aggregator);
     $priceFeed.tokenInDecimal = tokenInDecimal;
     $priceFeed.tokenOutDecimal = tokenOutDecimal;
-    $priceFeed.pairDecimal = int32(uint32(AggregatorV2V3Interface(aggregator).decimals()));
+    $priceFeed.pairDecimal = AggregatorV2V3Interface(aggregator).decimals();
     $priceFeed.maxAcceptableAge = maxAcceptableAge;
 
     emit ChainlinkPriceFeedUpdated(
@@ -52,67 +69,78 @@ library LibChainlinkPriceFeed {
     );
   }
 
-  function convertTokenIn2TokenOut(ChainlinkPriceFeed memory priceFeed, uint256 tokenInWei)
+  /**
+   * @dev Convert tokenIn amount to tokenOut amount.
+   * @param priceFeed The Chainlink price feed struct.
+   * @param tokenInAmount The amount of tokenIn.
+   * @return tokenOutAmount The amount of tokenOut.
+   */
+  function convertTokenIn2TokenOut(ChainlinkPriceFeed memory priceFeed, uint256 tokenInAmount)
     internal
     view
-    returns (uint256 tokenOutWei)
+    returns (uint256 tokenOutAmount)
   {
     uint256 price = quotePrice(priceFeed);
 
     // Scale the price to the same decimal as tokenOut
     uint256 scaledPrice = scalePrice(price, priceFeed.pairDecimal, priceFeed.tokenOutDecimal);
 
-    tokenOutWei = Math.mulDiv(scaledPrice, tokenInWei, LibPowMath.exp10(1, int32(uint32(priceFeed.tokenInDecimal))));
+    tokenOutAmount = Math.mulDiv(scaledPrice, tokenInAmount, 10 ** priceFeed.tokenInDecimal);
   }
 
-  function convertTokenOut2TokenIn(ChainlinkPriceFeed memory priceFeed, uint256 tokenOutWei)
+  /**
+   * @dev Converts the token out into token in.
+   * @param priceFeed The Chainlink price feed struct.
+   * @param tokenOutAmount The amount of token out amount.
+   * @return tokenInAmount The amount of token in amount.
+   */
+  function convertTokenOut2TokenIn(ChainlinkPriceFeed memory priceFeed, uint256 tokenOutAmount)
     internal
     view
-    returns (uint256 tokenInWei)
+    returns (uint256 tokenInAmount)
   {
     uint256 price = quotePrice(priceFeed);
 
     // Scale the price to the same decimal as tokenIn
-    // The price is in tokenOut, so we need to inverse it to get the tokenIn price
-    uint256 inversedPrice = inverse(int256(price), -priceFeed.pairDecimal, -priceFeed.tokenInDecimal);
+    // The price is in tokenOut, so we need to inverseAndScalePrice it to get the tokenIn price
+    uint256 inversedPrice = inverseAndScalePrice(price, priceFeed.pairDecimal, priceFeed.tokenInDecimal);
 
-    tokenInWei = Math.mulDiv(inversedPrice, tokenOutWei, LibPowMath.exp10(1, priceFeed.tokenOutDecimal));
+    tokenInAmount = Math.mulDiv(inversedPrice, tokenOutAmount, 10 ** priceFeed.tokenOutDecimal);
   }
 
+  /**
+   * @dev Get the price from the Chainlink price feed.
+   * @param priceFeed The Chainlink price feed.
+   * @return price The price in the given decimal.
+   */
   function quotePrice(ChainlinkPriceFeed memory priceFeed) internal view returns (uint256 price) {
-    try priceFeed.aggregator.latestAnswer() returns (int256 answer) {
-      price = uint256(answer);
-      uint256 latestTimestamp = priceFeed.aggregator.latestTimestamp();
-      if (latestTimestamp < block.timestamp - priceFeed.maxAcceptableAge) {
-        revert ExceededMaxAcceptableAge(latestTimestamp, block.timestamp - priceFeed.maxAcceptableAge);
-      }
-    } catch {
-      try priceFeed.aggregator.latestRoundData() returns (uint80, int256 answer, uint256, uint256 updatedAt, uint80) {
-        price = uint256(answer);
-        if (updatedAt < block.timestamp - priceFeed.maxAcceptableAge) {
-          revert ExceededMaxAcceptableAge(updatedAt, block.timestamp - priceFeed.maxAcceptableAge);
-        }
-      } catch {
-        revert QuotingPriceFailed();
-      }
+    (, int256 answer,, uint256 updatedAt,) = priceFeed.aggregator.latestRoundData();
+    if (updatedAt < block.timestamp - priceFeed.maxAcceptableAge) {
+      revert ExceededMaxAcceptableAge(updatedAt, block.timestamp - priceFeed.maxAcceptableAge);
     }
+
+    return uint256(answer);
   }
 
-  function scalePrice(uint256 price, int32 pairDecimal, int32 scaledDecimal) internal pure returns (uint256) {
-    return LibPowMath.exp10(price, scaledDecimal - pairDecimal);
+  /**
+   * @dev Scale the price to the given decimal.
+   * @param price The price in the given decimal.
+   * @param priceDecimal The decimal of the price.
+   * @param scaleDecimal The decimal to scale the price to.
+   * @return The scaled price in the given decimal.
+   */
+  function scalePrice(uint256 price, uint8 priceDecimal, uint8 scaleDecimal) internal pure returns (uint256) {
+    return price.exp10(int8(scaleDecimal) - int8(priceDecimal));
   }
 
-  function inverse(int256 price, int32 priceExpo, int32 expo) internal pure returns (uint256) {
-    if (priceExpo > 0) revert PositiveExponent(expo);
-
-    uint256 exp10p1 = LibPowMath.exp10(1, -priceExpo);
-    if (exp10p1 > uint256(type(int256).max)) revert ExponentTooLarge(priceExpo);
-
-    uint256 exp10p2 = LibPowMath.exp10(1, -expo);
-    if (exp10p2 > uint256(type(int256).max)) revert ExponentTooLarge(expo);
-
-    int256 inversedPrice = (int256(exp10p1) * int256(exp10p2)) / price;
-
-    return uint256(inversedPrice);
+  /**
+   * @dev Inverse the price of (A/B) to (B/A) and scale it to the given decimal.
+   * @param price The price of (A/B) in the given decimal.
+   * @param priceDecimal The decimal of the price.
+   * @param scaleDecimal The decimal to scale the price to.
+   * @return The price of (B/A) in the given decimal.
+   */
+  function inverseAndScalePrice(uint256 price, uint8 priceDecimal, uint8 scaleDecimal) internal pure returns (uint256) {
+    return Math.mulDiv(10 ** priceDecimal, 10 ** scaleDecimal, price);
   }
 }

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -127,9 +127,13 @@ library LibChainlinkPriceFeed {
    * @param price The price in the given decimal.
    * @param priceDecimal The decimal of the price.
    * @param scaleDecimal The decimal to scale the price to.
-   * @return The scaled price in the given decimal.
+   * @return scaledPrice The scaled price in the given decimal.
    */
-  function scalePrice(uint256 price, uint8 priceDecimal, uint8 scaleDecimal) internal pure returns (uint256) {
+  function scalePrice(uint256 price, uint8 priceDecimal, uint8 scaleDecimal)
+    internal
+    pure
+    returns (uint256 scaledPrice)
+  {
     return price.exp10(int8(scaleDecimal) - int8(priceDecimal));
   }
 
@@ -138,9 +142,13 @@ library LibChainlinkPriceFeed {
    * @param price The price of (A/B) in the given decimal.
    * @param priceDecimal The decimal of the price.
    * @param scaleDecimal The decimal to scale the price to.
-   * @return The price of (B/A) in the given decimal.
+   * @return inversedPrice The price of (B/A) scaled in the given decimal.
    */
-  function inverseAndScalePrice(uint256 price, uint8 priceDecimal, uint8 scaleDecimal) internal pure returns (uint256) {
+  function inverseAndScalePrice(uint256 price, uint8 priceDecimal, uint8 scaleDecimal)
+    internal
+    pure
+    returns (uint256 inversedPrice)
+  {
     return Math.mulDiv(10 ** priceDecimal, 10 ** scaleDecimal, price);
   }
 }

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -31,14 +31,13 @@ library LibChainlinkPriceFeed {
   /// @dev Thrown when the price is negative.
   error PanicNegativeQuotePrice(int256 answer);
   /// @dev Thrown when the computed price is too large.
-  error ComputedPriceTooLarge(uint256 price, uint8 priceDecimal, uint8 scaleDecimal);
+  error ComputedPriceTooLarge(uint256 price, int8 expo);
+  /// @dev Thrown when the computed price is too small.
+  error ComputedPriceTooSmall(uint256 price, int8 expo);
 
   /// @dev Emitted when the price feed is updated.
   event ChainlinkPriceFeedUpdated(
-    AggregatorV2V3Interface indexed aggregator,
-    uint8 tokenInDecimal,
-    uint8 tokenOutDecimal,
-    string description
+    AggregatorV2V3Interface indexed aggregator, uint8 tokenInDecimal, uint8 tokenOutDecimal, string description
   );
   /// @dev Emitted when the max acceptable age is updated.
   event MaxAcceptableAgeUpdated(AggregatorV2V3Interface indexed aggregator, uint64 maxAcceptableAge);
@@ -156,8 +155,13 @@ library LibChainlinkPriceFeed {
     pure
     returns (uint256 scaledPrice)
   {
-    uint256 abs = priceDecimal > scaleDecimal ? priceDecimal - scaleDecimal : scaleDecimal - priceDecimal;
-    if (Math.log10(price) + abs > _MAX_DECIMAL) revert ComputedPriceTooLarge(price, priceDecimal, scaleDecimal);
+    uint256 log10Price = Math.log10(price);
+    if (scaleDecimal > priceDecimal && log10Price + (scaleDecimal - priceDecimal) > _MAX_DECIMAL) {
+      revert ComputedPriceTooLarge(price, -(int8(scaleDecimal) - int8(priceDecimal)));
+    }
+    if (scaleDecimal < priceDecimal && log10Price < priceDecimal - scaleDecimal) {
+      revert ComputedPriceTooSmall(price, -(int8(priceDecimal) - int8(scaleDecimal)));
+    }
 
     return price.exp10(int8(scaleDecimal) - int8(priceDecimal));
   }
@@ -174,6 +178,10 @@ library LibChainlinkPriceFeed {
     pure
     returns (uint256 inversedPrice)
   {
-    return Math.mulDiv(10 ** priceDecimal, 10 ** scaleDecimal, price);
+    if (Math.log10(price) > priceDecimal + scaleDecimal) {
+      revert ComputedPriceTooSmall(price, -(int8(scaleDecimal) - int8(priceDecimal)));
+    }
+
+    return 10 ** (scaleDecimal + priceDecimal) / price;
   }
 }

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -11,6 +11,7 @@ struct ChainlinkPriceFeed {
   int32 pairDecimal;
   int32 tokenInDecimal;
   int32 tokenOutDecimal;
+  uint256 maxAcceptableAge;
 }
 
 using LibChainlinkPriceFeed for ChainlinkPriceFeed global;
@@ -19,23 +20,34 @@ library LibChainlinkPriceFeed {
   error QuotingPriceFailed();
   error ExponentTooLarge(int32 expo);
   error PositiveExponent(int32 expo);
+  error ExceededMaxAcceptableAge(uint256 latestTimestamp, uint256 maxAcceptableTimestamp);
 
   event ChainlinkPriceFeedUpdated(
-    AggregatorV2V3Interface indexed aggregator, int32 tokenInDecimal, int32 tokenOutDecimal, string description
+    AggregatorV2V3Interface indexed aggregator,
+    int32 tokenInDecimal,
+    int32 tokenOutDecimal,
+    uint256 maxAcceptableAge,
+    string description
   );
 
-  function set(ChainlinkPriceFeed storage $priceFeed, address aggregator, int32 tokenInDecimal, int32 tokenOutDecimal)
-    internal
-  {
+  function set(
+    ChainlinkPriceFeed storage $priceFeed,
+    address aggregator,
+    int32 tokenInDecimal,
+    int32 tokenOutDecimal,
+    uint256 maxAcceptableAge
+  ) internal {
     $priceFeed.aggregator = AggregatorV2V3Interface(aggregator);
     $priceFeed.tokenInDecimal = tokenInDecimal;
     $priceFeed.tokenOutDecimal = tokenOutDecimal;
     $priceFeed.pairDecimal = int32(uint32(AggregatorV2V3Interface(aggregator).decimals()));
+    $priceFeed.maxAcceptableAge = maxAcceptableAge;
 
     emit ChainlinkPriceFeedUpdated(
       AggregatorV2V3Interface(aggregator),
       tokenInDecimal,
       tokenOutDecimal,
+      maxAcceptableAge,
       AggregatorV2V3Interface(aggregator).description()
     );
   }
@@ -70,9 +82,16 @@ library LibChainlinkPriceFeed {
   function quotePrice(ChainlinkPriceFeed memory priceFeed) internal view returns (uint256 price) {
     try priceFeed.aggregator.latestAnswer() returns (int256 answer) {
       price = uint256(answer);
+      uint256 latestTimestamp = priceFeed.aggregator.latestTimestamp();
+      if (latestTimestamp < block.timestamp - priceFeed.maxAcceptableAge) {
+        revert ExceededMaxAcceptableAge(latestTimestamp, block.timestamp - priceFeed.maxAcceptableAge);
+      }
     } catch {
-      try priceFeed.aggregator.latestRoundData() returns (uint80, int256 answer, uint256, uint256, uint80) {
+      try priceFeed.aggregator.latestRoundData() returns (uint80, int256 answer, uint256, uint256 updatedAt, uint80) {
         price = uint256(answer);
+        if (updatedAt < block.timestamp - priceFeed.maxAcceptableAge) {
+          revert ExceededMaxAcceptableAge(updatedAt, block.timestamp - priceFeed.maxAcceptableAge);
+        }
       } catch {
         revert QuotingPriceFailed();
       }

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -7,11 +7,11 @@ import { Math } from "../../../dependencies/openzeppelin-4.9.6/contracts/utils/m
 import { LibPowMath } from "../../math/LibPowMath.sol";
 
 struct ChainlinkPriceFeed {
-  AggregatorV2V3Interface aggregator;
-  uint8 pairDecimal;
-  uint8 tokenInDecimal;
-  uint8 tokenOutDecimal;
-  uint64 maxAcceptableAge;
+  AggregatorV2V3Interface _aggregator;
+  uint8 _pairDecimal;
+  uint8 _tokenInDecimal;
+  uint8 _tokenOutDecimal;
+  uint64 _maxAcceptableAge;
 }
 
 using LibChainlinkPriceFeed for ChainlinkPriceFeed global;
@@ -39,14 +39,14 @@ library LibChainlinkPriceFeed {
 
   /**
    * @dev Sets the price feed for a token.
-   * @param $priceFeed The Chainlink price feed storage variable.
+   * @param $ The Chainlink price feed storage variable.
    * @param aggregator The address of the Chainlink aggregator.
    * @param tokenInDecimal The decimal of token in.
    * @param tokenOutDecimal The decimal of token out.
    * @param maxAcceptableAge The max acceptable age for the price.
    */
   function set(
-    ChainlinkPriceFeed storage $priceFeed,
+    ChainlinkPriceFeed storage $,
     address aggregator,
     uint8 tokenInDecimal,
     uint8 tokenOutDecimal,
@@ -55,11 +55,11 @@ library LibChainlinkPriceFeed {
     if (tokenInDecimal > _MAX_DECIMALS) revert LargeDecimal(tokenInDecimal);
     if (tokenOutDecimal > _MAX_DECIMALS) revert LargeDecimal(tokenOutDecimal);
 
-    $priceFeed.aggregator = AggregatorV2V3Interface(aggregator);
-    $priceFeed.tokenInDecimal = tokenInDecimal;
-    $priceFeed.tokenOutDecimal = tokenOutDecimal;
-    $priceFeed.pairDecimal = AggregatorV2V3Interface(aggregator).decimals();
-    $priceFeed.maxAcceptableAge = maxAcceptableAge;
+    $._aggregator = AggregatorV2V3Interface(aggregator);
+    $._tokenInDecimal = tokenInDecimal;
+    $._tokenOutDecimal = tokenOutDecimal;
+    $._pairDecimal = AggregatorV2V3Interface(aggregator).decimals();
+    $._maxAcceptableAge = maxAcceptableAge;
 
     emit ChainlinkPriceFeedUpdated(
       AggregatorV2V3Interface(aggregator),
@@ -84,9 +84,9 @@ library LibChainlinkPriceFeed {
     uint256 price = quotePrice(priceFeed);
 
     // Scale the price to the same decimal as tokenOut
-    uint256 scaledPrice = scalePrice(price, priceFeed.pairDecimal, priceFeed.tokenOutDecimal);
+    uint256 scaledPrice = scalePrice(price, priceFeed._pairDecimal, priceFeed._tokenOutDecimal);
 
-    tokenOutAmount = Math.mulDiv(scaledPrice, tokenInAmount, 10 ** priceFeed.tokenInDecimal);
+    tokenOutAmount = Math.mulDiv(scaledPrice, tokenInAmount, 10 ** priceFeed._tokenInDecimal);
   }
 
   /**
@@ -104,9 +104,9 @@ library LibChainlinkPriceFeed {
 
     // Scale the price to the same decimal as tokenIn
     // The price is in tokenOut, so we need to inverseAndScalePrice it to get the tokenIn price
-    uint256 inversedPrice = inverseAndScalePrice(price, priceFeed.pairDecimal, priceFeed.tokenInDecimal);
+    uint256 inversedPrice = inverseAndScalePrice(price, priceFeed._pairDecimal, priceFeed._tokenInDecimal);
 
-    tokenInAmount = Math.mulDiv(inversedPrice, tokenOutAmount, 10 ** priceFeed.tokenOutDecimal);
+    tokenInAmount = Math.mulDiv(inversedPrice, tokenOutAmount, 10 ** priceFeed._tokenOutDecimal);
   }
 
   /**
@@ -115,9 +115,9 @@ library LibChainlinkPriceFeed {
    * @return price The price in the given decimal.
    */
   function quotePrice(ChainlinkPriceFeed memory priceFeed) internal view returns (uint256 price) {
-    (, int256 answer,, uint256 updatedAt,) = priceFeed.aggregator.latestRoundData();
-    if (updatedAt < block.timestamp - priceFeed.maxAcceptableAge) {
-      revert ExceededMaxAcceptableAge(updatedAt, block.timestamp - priceFeed.maxAcceptableAge);
+    (, int256 answer,, uint256 updatedAt,) = priceFeed._aggregator.latestRoundData();
+    if (updatedAt < block.timestamp - priceFeed._maxAcceptableAge) {
+      revert ExceededMaxAcceptableAge(updatedAt, block.timestamp - priceFeed._maxAcceptableAge);
     }
 
     return uint256(answer);

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { AggregatorV2V3Interface } from
+  "../../../dependencies/chainlink-2.21.0/contracts/src/v0.8/shared/interfaces/AggregatorV2V3Interface.sol";
+import { Math } from "../../../dependencies/openzeppelin-4.9.6/contracts/utils/math/Math.sol";
+import { LibPowMath } from "../../math/LibPowMath.sol";
+
+struct ChainlinkPriceFeed {
+  AggregatorV2V3Interface aggregator;
+  int32 pairDecimal;
+  int32 tokenInDecimal;
+  int32 tokenOutDecimal;
+}
+
+using LibChainlinkPriceFeed for ChainlinkPriceFeed global;
+
+library LibChainlinkPriceFeed {
+  error QuotingPriceFailed();
+  error ExponentTooLarge(int32 expo);
+  error PositiveExponent(int32 expo);
+
+  event ChainlinkPriceFeedUpdated(
+    AggregatorV2V3Interface indexed aggregator, int32 tokenInDecimal, int32 tokenOutDecimal, string description
+  );
+
+  function set(ChainlinkPriceFeed storage $priceFeed, address aggregator, int32 tokenInDecimal, int32 tokenOutDecimal)
+    internal
+  {
+    $priceFeed.aggregator = AggregatorV2V3Interface(aggregator);
+    $priceFeed.tokenInDecimal = tokenInDecimal;
+    $priceFeed.tokenOutDecimal = tokenOutDecimal;
+    $priceFeed.pairDecimal = int32(uint32(AggregatorV2V3Interface(aggregator).decimals()));
+
+    emit ChainlinkPriceFeedUpdated(
+      AggregatorV2V3Interface(aggregator),
+      tokenInDecimal,
+      tokenOutDecimal,
+      AggregatorV2V3Interface(aggregator).description()
+    );
+  }
+
+  function convertTokenIn2TokenOut(ChainlinkPriceFeed memory priceFeed, uint256 tokenInWei)
+    internal
+    view
+    returns (uint256 tokenOutWei)
+  {
+    uint256 price = quotePrice(priceFeed);
+
+    // Scale the price to the same decimal as tokenOut
+    uint256 scaledPrice = scalePrice(price, priceFeed.pairDecimal, priceFeed.tokenOutDecimal);
+
+    tokenOutWei = Math.mulDiv(scaledPrice, tokenInWei, LibPowMath.exp10(1, int32(uint32(priceFeed.tokenInDecimal))));
+  }
+
+  function convertTokenOut2TokenIn(ChainlinkPriceFeed memory priceFeed, uint256 tokenOutWei)
+    internal
+    view
+    returns (uint256 tokenInWei)
+  {
+    uint256 price = quotePrice(priceFeed);
+
+    // Scale the price to the same decimal as tokenIn
+    // The price is in tokenOut, so we need to inverse it to get the tokenIn price
+    uint256 inversedPrice = inverse(int256(price), -priceFeed.pairDecimal, -priceFeed.tokenInDecimal);
+
+    tokenInWei = Math.mulDiv(inversedPrice, tokenOutWei, LibPowMath.exp10(1, priceFeed.tokenOutDecimal));
+  }
+
+  function quotePrice(ChainlinkPriceFeed memory priceFeed) internal view returns (uint256 price) {
+    try priceFeed.aggregator.latestAnswer() returns (int256 answer) {
+      price = uint256(answer);
+    } catch {
+      try priceFeed.aggregator.latestRoundData() returns (uint80, int256 answer, uint256, uint256, uint80) {
+        price = uint256(answer);
+      } catch {
+        revert QuotingPriceFailed();
+      }
+    }
+  }
+
+  function scalePrice(uint256 price, int32 pairDecimal, int32 scaledDecimal) internal pure returns (uint256) {
+    return LibPowMath.exp10(price, scaledDecimal - pairDecimal);
+  }
+
+  function inverse(int256 price, int32 priceExpo, int32 expo) internal pure returns (uint256) {
+    if (priceExpo > 0) revert PositiveExponent(expo);
+
+    uint256 exp10p1 = LibPowMath.exp10(1, -priceExpo);
+    if (exp10p1 > uint256(type(int256).max)) revert ExponentTooLarge(priceExpo);
+
+    uint256 exp10p2 = LibPowMath.exp10(1, -expo);
+    if (exp10p2 > uint256(type(int256).max)) revert ExponentTooLarge(expo);
+
+    int256 inversedPrice = (int256(exp10p1) * int256(exp10p2)) / price;
+
+    return uint256(inversedPrice);
+  }
+}

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -8,7 +8,6 @@ import { LibPowMath } from "../../math/LibPowMath.sol";
 
 struct ChainlinkPriceFeed {
   AggregatorV2V3Interface _aggregator;
-  uint8 _pairDecimal;
   uint8 _tokenInDecimal;
   uint8 _tokenOutDecimal;
   uint64 _maxAcceptableAge;
@@ -37,7 +36,6 @@ library LibChainlinkPriceFeed {
   /// @dev Emitted when the price feed is updated.
   event ChainlinkPriceFeedUpdated(
     AggregatorV2V3Interface indexed aggregator,
-    uint8 pairDecimal,
     uint8 tokenInDecimal,
     uint8 tokenOutDecimal,
     string description
@@ -60,21 +58,16 @@ library LibChainlinkPriceFeed {
     uint8 tokenOutDecimal,
     uint64 maxAcceptableAge
   ) internal {
-    uint8 pairDecimal = AggregatorV2V3Interface(aggregator).decimals();
-
     if (tokenInDecimal > _DECIMAL_LIMIT) revert LargeDecimal(tokenInDecimal);
     if (tokenOutDecimal > _DECIMAL_LIMIT) revert LargeDecimal(tokenOutDecimal);
-    if (pairDecimal > _DECIMAL_LIMIT) revert LargeDecimal(pairDecimal);
 
     $._aggregator = AggregatorV2V3Interface(aggregator);
     $._tokenInDecimal = tokenInDecimal;
     $._tokenOutDecimal = tokenOutDecimal;
-    $._pairDecimal = pairDecimal;
     $._maxAcceptableAge = maxAcceptableAge;
 
     emit ChainlinkPriceFeedUpdated(
       AggregatorV2V3Interface(aggregator),
-      pairDecimal,
       tokenInDecimal,
       tokenOutDecimal,
       AggregatorV2V3Interface(aggregator).description()
@@ -105,10 +98,10 @@ library LibChainlinkPriceFeed {
     view
     returns (uint256 tokenOutAmount)
   {
-    uint256 price = quotePrice(priceFeed);
+    (uint256 price, uint8 priceDecimal) = quotePrice(priceFeed);
 
     // Scale the price to the same decimal as tokenOut
-    uint256 scaledPrice = scalePrice(price, priceFeed._pairDecimal, priceFeed._tokenOutDecimal);
+    uint256 scaledPrice = scalePrice(price, priceDecimal, priceFeed._tokenOutDecimal);
 
     tokenOutAmount = Math.mulDiv(scaledPrice, tokenInAmount, 10 ** priceFeed._tokenInDecimal);
   }
@@ -124,11 +117,11 @@ library LibChainlinkPriceFeed {
     view
     returns (uint256 tokenInAmount)
   {
-    uint256 price = quotePrice(priceFeed);
+    (uint256 price, uint8 priceDecimal) = quotePrice(priceFeed);
 
     // Scale the price to the same decimal as tokenIn
     // The price is in tokenOut, so we need to inverseAndScalePrice it to get the tokenIn price
-    uint256 inversedPrice = inverseAndScalePrice(price, priceFeed._pairDecimal, priceFeed._tokenInDecimal);
+    uint256 inversedPrice = inverseAndScalePrice(price, priceDecimal, priceFeed._tokenInDecimal);
 
     tokenInAmount = Math.mulDiv(inversedPrice, tokenOutAmount, 10 ** priceFeed._tokenOutDecimal);
   }
@@ -138,14 +131,17 @@ library LibChainlinkPriceFeed {
    * @param priceFeed The Chainlink price feed.
    * @return price The price in the given decimal.
    */
-  function quotePrice(ChainlinkPriceFeed memory priceFeed) internal view returns (uint256 price) {
+  function quotePrice(ChainlinkPriceFeed memory priceFeed) internal view returns (uint256 price, uint8 priceDecimal) {
     (, int256 answer,, uint256 updatedAt,) = priceFeed._aggregator.latestRoundData();
     if (updatedAt < block.timestamp - priceFeed._maxAcceptableAge) {
       revert PriceTooOld(updatedAt, block.timestamp - priceFeed._maxAcceptableAge);
     }
     if (answer <= 0) revert PanicNegativeQuotePrice(answer);
 
-    return uint256(answer);
+    priceDecimal = priceFeed._aggregator.decimals();
+    if (priceDecimal > _DECIMAL_LIMIT) revert LargeDecimal(priceDecimal);
+
+    return (uint256(answer), priceDecimal);
   }
 
   /**

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -147,41 +147,49 @@ library LibChainlinkPriceFeed {
    * @dev Scale the price to the given decimal.
    * @param price The price in the given decimal.
    * @param priceDecimal The decimal of the price.
-   * @param scaleDecimal The decimal to scale the price to.
+   * @param desiredDecimal The decimal to scale the price to.
    * @return scaledPrice The scaled price in the given decimal.
    */
-  function scalePrice(uint256 price, uint8 priceDecimal, uint8 scaleDecimal)
+  function scalePrice(uint256 price, uint8 priceDecimal, uint8 desiredDecimal)
     internal
     pure
     returns (uint256 scaledPrice)
   {
     uint256 log10Price = Math.log10(price);
-    if (scaleDecimal > priceDecimal && log10Price + (scaleDecimal - priceDecimal) > _MAX_DECIMAL) {
-      revert ComputedPriceTooLarge(price, -(int8(scaleDecimal) - int8(priceDecimal)));
+    if (desiredDecimal > priceDecimal && log10Price + (desiredDecimal - priceDecimal) > _MAX_DECIMAL) {
+      revert ComputedPriceTooLarge(price, -(int8(desiredDecimal) - int8(priceDecimal)));
     }
-    if (scaleDecimal < priceDecimal && log10Price < priceDecimal - scaleDecimal) {
-      revert ComputedPriceTooSmall(price, -(int8(priceDecimal) - int8(scaleDecimal)));
+    if (desiredDecimal < priceDecimal && log10Price < priceDecimal - desiredDecimal) {
+      revert ComputedPriceTooSmall(price, -(int8(priceDecimal) - int8(desiredDecimal)));
     }
 
-    return price.exp10(int8(scaleDecimal) - int8(priceDecimal));
+    return price.exp10(int8(desiredDecimal) - int8(priceDecimal));
   }
 
   /**
-   * @dev Inverse the price of (A/B) to (B/A) and scale it to the given decimal.
-   * @param price The price of (A/B) in the given decimal.
-   * @param priceDecimal The decimal of the price.
-   * @param scaleDecimal The decimal to scale the price to.
-   * @return inversedPrice The price of (B/A) scaled in the given decimal.
+   * @dev Computes the inverse price of an asset pair (B/A) from (A/B) and scales it to the desired decimal precision.
+   *
+   * Given the price of (A/B), denoted as `x`, with decimal precision `d`, and the desired decimal `d'`,
+   * the inverse price (B/A), denoted as `y`, is computed as:
+   *
+   *     y = (1 / x) * 10^d * 10^d'
+   *       = (10^d / x) * 10^d'
+   *       = 10^(d + d') / x
+   *
+   * @param price The price of (A/B) with `priceDecimal` precision.
+   * @param priceDecimal The number of decimal places in `price`.
+   * @param desiredDecimal The target number of decimal places for the inverse price.
+   * @return inversedPrice The computed price of (B/A) scaled to `desiredDecimal`.
    */
-  function inverseAndScalePrice(uint256 price, uint8 priceDecimal, uint8 scaleDecimal)
+  function inverseAndScalePrice(uint256 price, uint8 priceDecimal, uint8 desiredDecimal)
     internal
     pure
     returns (uint256 inversedPrice)
   {
-    if (Math.log10(price) > priceDecimal + scaleDecimal) {
-      revert ComputedPriceTooSmall(price, -(int8(scaleDecimal) - int8(priceDecimal)));
+    if (Math.log10(price) > priceDecimal + desiredDecimal) {
+      revert ComputedPriceTooSmall(price, -(int8(desiredDecimal) - int8(priceDecimal)));
     }
 
-    return 10 ** (scaleDecimal + priceDecimal) / price;
+    return 10 ** (desiredDecimal + priceDecimal) / price;
   }
 }

--- a/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
+++ b/src/price-feeds/chainlink/LibChainlinkPriceFeed.sol
@@ -21,23 +21,29 @@ library LibChainlinkPriceFeed {
 
   /// @dev The maximum decimal for the token.
   /// @dev This is used to prevent overflow when scaling the price.
-  uint8 internal constant _MAX_DECIMALS = 30;
+  uint8 internal constant _DECIMAL_LIMIT = 30;
+  /// @dev Value of log10(2**256 - 1)
+  uint8 internal constant _MAX_DECIMAL = 77;
 
-  /// @dev Thrown when the decimal is larger than the maximum decimal.
+  /// @dev Thrown when the decimal is larger than the limit decimal.
   error LargeDecimal(uint8 decimal);
   /// @dev Thrown when the price update timestamp is older than the max acceptable age.
-  error ExceededMaxAcceptableAge(uint256 latestTimestamp, uint256 maxAcceptableTimestamp);
+  error PriceTooOld(uint256 latestTimestamp, uint256 maxAcceptableTimestamp);
   /// @dev Thrown when the price is negative.
-  error PanicQuotePrice(int256 answer);
+  error PanicNegativeQuotePrice(int256 answer);
+  /// @dev Thrown when the computed price is too large.
+  error ComputedPriceTooLarge(uint256 price, uint8 priceDecimal, uint8 scaleDecimal);
 
   /// @dev Emitted when the price feed is updated.
   event ChainlinkPriceFeedUpdated(
     AggregatorV2V3Interface indexed aggregator,
+    uint8 pairDecimal,
     uint8 tokenInDecimal,
     uint8 tokenOutDecimal,
-    uint64 maxAcceptableAge,
     string description
   );
+  /// @dev Emitted when the max acceptable age is updated.
+  event MaxAcceptableAgeUpdated(AggregatorV2V3Interface indexed aggregator, uint64 maxAcceptableAge);
 
   /**
    * @dev Sets the price feed for a token.
@@ -54,22 +60,38 @@ library LibChainlinkPriceFeed {
     uint8 tokenOutDecimal,
     uint64 maxAcceptableAge
   ) internal {
-    if (tokenInDecimal > _MAX_DECIMALS) revert LargeDecimal(tokenInDecimal);
-    if (tokenOutDecimal > _MAX_DECIMALS) revert LargeDecimal(tokenOutDecimal);
+    uint8 pairDecimal = AggregatorV2V3Interface(aggregator).decimals();
+
+    if (tokenInDecimal > _DECIMAL_LIMIT) revert LargeDecimal(tokenInDecimal);
+    if (tokenOutDecimal > _DECIMAL_LIMIT) revert LargeDecimal(tokenOutDecimal);
+    if (pairDecimal > _DECIMAL_LIMIT) revert LargeDecimal(pairDecimal);
 
     $._aggregator = AggregatorV2V3Interface(aggregator);
     $._tokenInDecimal = tokenInDecimal;
     $._tokenOutDecimal = tokenOutDecimal;
-    $._pairDecimal = AggregatorV2V3Interface(aggregator).decimals();
+    $._pairDecimal = pairDecimal;
     $._maxAcceptableAge = maxAcceptableAge;
 
     emit ChainlinkPriceFeedUpdated(
       AggregatorV2V3Interface(aggregator),
+      pairDecimal,
       tokenInDecimal,
       tokenOutDecimal,
-      maxAcceptableAge,
       AggregatorV2V3Interface(aggregator).description()
     );
+
+    emit MaxAcceptableAgeUpdated(AggregatorV2V3Interface(aggregator), maxAcceptableAge);
+  }
+
+  /**
+   * @dev Sets the max acceptable age for the price.
+   * @param $ The Chainlink price feed storage variable.
+   * @param maxAcceptableAge The max acceptable age for the price.
+   */
+  function setMaxAcceptableAge(ChainlinkPriceFeed storage $, uint64 maxAcceptableAge) internal {
+    $._maxAcceptableAge = maxAcceptableAge;
+
+    emit MaxAcceptableAgeUpdated(AggregatorV2V3Interface($._aggregator), maxAcceptableAge);
   }
 
   /**
@@ -119,9 +141,9 @@ library LibChainlinkPriceFeed {
   function quotePrice(ChainlinkPriceFeed memory priceFeed) internal view returns (uint256 price) {
     (, int256 answer,, uint256 updatedAt,) = priceFeed._aggregator.latestRoundData();
     if (updatedAt < block.timestamp - priceFeed._maxAcceptableAge) {
-      revert ExceededMaxAcceptableAge(updatedAt, block.timestamp - priceFeed._maxAcceptableAge);
+      revert PriceTooOld(updatedAt, block.timestamp - priceFeed._maxAcceptableAge);
     }
-    if (answer <= 0) revert PanicQuotePrice(answer);
+    if (answer <= 0) revert PanicNegativeQuotePrice(answer);
 
     return uint256(answer);
   }
@@ -138,6 +160,9 @@ library LibChainlinkPriceFeed {
     pure
     returns (uint256 scaledPrice)
   {
+    uint256 abs = priceDecimal > scaleDecimal ? priceDecimal - scaleDecimal : scaleDecimal - priceDecimal;
+    if (Math.log10(price) + abs > _MAX_DECIMAL) revert ComputedPriceTooLarge(price, priceDecimal, scaleDecimal);
+
     return price.exp10(int8(scaleDecimal) - int8(priceDecimal));
   }
 

--- a/src/price-feeds/pyth/LibPythPriceFeed.sol
+++ b/src/price-feeds/pyth/LibPythPriceFeed.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { PythStructs } from "../../../dependencies/pyth-2.2.0/PythStructs.sol";
+import { Math } from "../../../dependencies/openzeppelin-4.9.6/contracts/utils/math/Math.sol";
+import { LibPowMath } from "../../math/LibPowMath.sol";
+import { IPyth } from "../../../dependencies/pyth-2.2.0/IPyth.sol";
+
+struct PythPriceFeed {
+  uint8 tokenInDecimal;
+  uint8 tokenOutDecimal;
+  IPyth pyth;
+  bytes32 priceId;
+  uint256 maxAcceptableAge;
+}
+
+using LibPythPriceFeed for PythPriceFeed global;
+
+library LibPythPriceFeed {
+  using LibPythPriceFeed for PythStructs.Price;
+
+  error ErrExponentTooLarge(int32 expo);
+  error ErrComputedPriceTooLarge(int32 expo1, int32 expo2, int64 price1);
+  error ErrPositiveExponent(int32 expo);
+
+  /**
+   * @dev Emitted when the price feed is updated.
+   * @param pyth The Pyth contract.
+   * @param priceId The price id.
+   * @param tokenInDecimal The decimal of the token in.
+   * @param tokenOutDecimal The decimal of the token out.
+   * @param maxAcceptableAge The max acceptable age for the price.
+   */
+  event PythPriceFeedUpdated(
+    IPyth indexed pyth, bytes32 indexed priceId, uint8 tokenInDecimal, uint8 tokenOutDecimal, uint256 maxAcceptableAge
+  );
+
+  /**
+   * @dev Sets the price feed for a token.
+   * @param priceFeed The price feed.
+   * @param pyth The Pyth contract.
+   * @param tokenInDecimal The decimal of token in.
+   * @param tokenOutDecimal The decimal of token out.
+   * @param priceId The price id.
+   * @param maxAcceptableAge The max acceptable age for the price.
+   */
+  function set(
+    PythPriceFeed storage priceFeed,
+    address pyth,
+    uint8 tokenInDecimal,
+    uint8 tokenOutDecimal,
+    bytes32 priceId,
+    uint256 maxAcceptableAge
+  ) internal {
+    priceFeed.pyth = IPyth(pyth);
+    priceFeed.priceId = priceId;
+    priceFeed.tokenInDecimal = tokenInDecimal;
+    priceFeed.tokenOutDecimal = tokenOutDecimal;
+    priceFeed.maxAcceptableAge = maxAcceptableAge;
+
+    emit PythPriceFeedUpdated(IPyth(pyth), priceId, tokenInDecimal, tokenOutDecimal, maxAcceptableAge);
+  }
+
+  /**
+   * @dev Converts the token in into token out.
+   */
+  function convertTokenIn2TokenOut(PythPriceFeed memory priceFeed, uint256 tokenInWei)
+    internal
+    view
+    returns (uint256 tokenOutWei)
+  {
+    return priceFeed.pyth.getPriceNoOlderThan(priceFeed.priceId, priceFeed.maxAcceptableAge).mul({
+      inpWei: tokenInWei,
+      inpDecimals: int32(uint32(priceFeed.tokenInDecimal)),
+      outDecimals: int32(uint32(priceFeed.tokenOutDecimal))
+    });
+  }
+
+  /**
+   * @dev Converts the token out into token in.
+   */
+  function convertTokenOut2TokenIn(PythPriceFeed memory priceFeed, uint256 tokenOutWei)
+    internal
+    view
+    returns (uint256 tokenInWei)
+  {
+    return priceFeed.pyth.getPriceNoOlderThan(priceFeed.priceId, priceFeed.maxAcceptableAge).inverse({
+      expo: -int32(uint32(priceFeed.tokenInDecimal))
+    }).mul({
+      inpWei: tokenOutWei,
+      inpDecimals: int32(uint32(priceFeed.tokenOutDecimal)),
+      outDecimals: int32(uint32(priceFeed.tokenInDecimal))
+    });
+  }
+
+  /**
+   * @dev Multiples and converts the price into token wei with decimals `outDecimals`.
+   */
+  function mul(PythStructs.Price memory self, uint256 inpWei, int32 inpDecimals, int32 outDecimals)
+    internal
+    pure
+    returns (uint256 outWei)
+  {
+    return Math.mulDiv(
+      inpWei, LibPowMath.exp10(uint256(int256(self.price)), outDecimals + self.expo), LibPowMath.exp10(1, inpDecimals)
+    );
+  }
+
+  /**
+   * @dev Inverses token price of tokenA/tokenB to tokenB/tokenA.
+   */
+  function inverse(PythStructs.Price memory self, int32 expo) internal pure returns (PythStructs.Price memory outPrice) {
+    if (self.expo > 0) revert ErrPositiveExponent(expo);
+
+    uint256 exp10p1 = LibPowMath.exp10(1, -self.expo);
+    if (exp10p1 > uint256(type(int256).max)) revert ErrExponentTooLarge(self.expo);
+
+    uint256 exp10p2 = LibPowMath.exp10(1, -expo);
+    if (exp10p2 > uint256(type(int256).max)) revert ErrExponentTooLarge(expo);
+
+    int256 price = (int256(exp10p1) * int256(exp10p2)) / self.price;
+    if (price > type(int64).max) revert ErrComputedPriceTooLarge(self.expo, expo, self.price);
+
+    return PythStructs.Price({ price: int64(price), conf: self.conf, expo: expo, publishTime: self.publishTime });
+  }
+}

--- a/src/price-feeds/pyth/LibPythPriceFeed.sol
+++ b/src/price-feeds/pyth/LibPythPriceFeed.sol
@@ -110,7 +110,7 @@ library LibPythPriceFeed {
    * @dev Inverses token price of tokenA/tokenB to tokenB/tokenA.
    */
   function inverse(PythStructs.Price memory self, int32 expo) internal pure returns (PythStructs.Price memory outPrice) {
-    if (self.expo > 0) revert ErrPositiveExponent(expo);
+    if (self.expo > 0) revert ErrPositiveExponent(self.expo);
 
     uint256 exp10p1 = LibPowMath.exp10(1, -self.expo);
     if (exp10p1 > uint256(type(int256).max)) revert ErrExponentTooLarge(self.expo);

--- a/test/price-feeds/LibChainlinkPriceFeed.t.sol
+++ b/test/price-feeds/LibChainlinkPriceFeed.t.sol
@@ -174,11 +174,11 @@ contract LibChainlinkPriceFeedTest is Test {
 
   function testConcrete_ConvertRON2USD() public {
     ChainlinkPriceFeed memory converter = ChainlinkPriceFeed({
-      aggregator: AggregatorV2V3Interface(address(new MockRONPriceFeed())),
-      pairDecimal: 8,
-      tokenInDecimal: 18,
-      tokenOutDecimal: 18,
-      maxAcceptableAge: 1 days
+      _aggregator: AggregatorV2V3Interface(address(new MockRONPriceFeed())),
+      _pairDecimal: 8,
+      _tokenInDecimal: 18,
+      _tokenOutDecimal: 18,
+      _maxAcceptableAge: 1 days
     });
 
     uint256 ronAmount = 50e18;
@@ -189,11 +189,11 @@ contract LibChainlinkPriceFeedTest is Test {
 
   function testConcrete_ConvertUSD2RON() public {
     ChainlinkPriceFeed memory converter = ChainlinkPriceFeed({
-      aggregator: AggregatorV2V3Interface(address(new MockRONPriceFeed())),
-      pairDecimal: 8,
-      tokenInDecimal: 18,
-      tokenOutDecimal: 18,
-      maxAcceptableAge: 1 days
+      _aggregator: AggregatorV2V3Interface(address(new MockRONPriceFeed())),
+      _pairDecimal: 8,
+      _tokenInDecimal: 18,
+      _tokenOutDecimal: 18,
+      _maxAcceptableAge: 1 days
     });
 
     uint256 usdAmount = 100e18;

--- a/test/price-feeds/LibChainlinkPriceFeed.t.sol
+++ b/test/price-feeds/LibChainlinkPriceFeed.t.sol
@@ -50,7 +50,7 @@ contract PythPriceRONQuoterSample {
 contract ChainlinkPriceRONQuoterSample {
   ChainlinkPriceFeed public ronPriceFeed;
 
-  function set(address aggregator, int32 tokenInDecimal, int32 tokenOutDecimal) external {
+  function set(address aggregator, uint8 tokenInDecimal, uint8 tokenOutDecimal) external {
     ronPriceFeed.set(aggregator, tokenInDecimal, tokenOutDecimal, 1 days);
   }
 
@@ -210,16 +210,16 @@ contract LibChainlinkPriceFeedTest is Test {
     safePrecision(uint256(price), decimal)
     safePrecision(uint256(price), priceDecimal)
   {
-    vm.assume(priceDecimal < 19);
-    vm.assume(decimal < 19);
+    vm.assume(priceDecimal < 30);
+    vm.assume(decimal < 30);
     vm.assume(price > 0);
 
-    uint256 got = LibChainlinkPriceFeed.inverse(int256(price), -int32(uint32(priceDecimal)), -int32(uint32(decimal)));
+    uint256 got = LibChainlinkPriceFeed.inverseAndScalePrice(price, priceDecimal, decimal);
 
     // Python script to calculate the expected value
     // print('res:', int(1e{priceDecimal}/{price} * 10**{decimal}))
     string[] memory cmd = new string[](3);
-    cmd[0] = "python";
+    cmd[0] = "python3";
     cmd[1] = "-c";
     cmd[2] = string.concat(
       "print('res:',",
@@ -244,29 +244,29 @@ contract LibChainlinkPriceFeedTest is Test {
 
   function testConcrete_Inverse() public pure {
     // Case 0: priceExpo == expo
-    int256 price = 1e8;
-    int32 expo = -8;
-    uint256 weiPrice = LibChainlinkPriceFeed.inverse(price, expo, expo);
+    uint256 price = 1e8;
+    uint8 decimal = 8;
+    uint256 weiPrice = LibChainlinkPriceFeed.inverseAndScalePrice(price, decimal, decimal);
     assertEq(weiPrice, 100000000, "Incorrect inverse price");
 
-    // Case 1: priceExpo > expo
+    // Case 1: priceExpo > decimal
     // WBTC/USD price
     price = 334172000;
-    expo = -8;
-    uint256 weiPrice2 = LibChainlinkPriceFeed.inverse(price, expo, -18);
+    decimal = 8;
+    uint256 weiPrice2 = LibChainlinkPriceFeed.inverseAndScalePrice(price, decimal, 18);
     assertEq(weiPrice2, 299247094310714242, "Incorrect inverse price");
     assertApproxEqAbs(
-      LibChainlinkPriceFeed.inverse(int256(weiPrice2), -18, expo), uint256(price), 100, "Incorrect inverse price"
+      LibChainlinkPriceFeed.inverseAndScalePrice(weiPrice2, 18, decimal), price, 100, "Incorrect inverse price"
     );
 
-    // Case 2: priceExpo < expo
+    // Case 2: priceExpo < decimal
     // USDC/USD price
     price = 99992523;
-    expo = -8;
-    uint256 weiPrice3 = LibChainlinkPriceFeed.inverse(price, expo, -6);
+    decimal = 8;
+    uint256 weiPrice3 = LibChainlinkPriceFeed.inverseAndScalePrice(price, decimal, 6);
     assertEq(weiPrice3, 1000074, "Incorrect inverse price");
     assertApproxEqAbs(
-      LibChainlinkPriceFeed.inverse(int256(weiPrice3), -6, expo), uint256(price), 100, "Incorrect inverse price"
+      LibChainlinkPriceFeed.inverseAndScalePrice(weiPrice3, 6, decimal), price, 100, "Incorrect inverse price"
     );
   }
 
@@ -276,18 +276,18 @@ contract LibChainlinkPriceFeedTest is Test {
     uint8 priceDecimal = 8;
 
     // Case 1: priceDecimal == decimal
-    assertEq(price, LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 8), "Incorrect price scaling");
+    assertEq(price, LibChainlinkPriceFeed.scalePrice(price, priceDecimal, 8), "Incorrect price scaling");
 
     // Case 2: priceDecimal < decimal
-    uint256 weiPrice = LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 18);
+    uint256 weiPrice = LibChainlinkPriceFeed.scalePrice(price, priceDecimal, 18);
     assertEq(weiPrice, 3341720000000000000, "Incorrect price scaling");
 
     // Case 3: priceDecimal > decimal
-    uint256 weiPrice2 = LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 6);
+    uint256 weiPrice2 = LibChainlinkPriceFeed.scalePrice(price, priceDecimal, 6);
     assertEq(weiPrice2, 3341720, "Incorrect price scaling");
 
     // Case 4: reverse scaling
-    uint256 oriPrice = LibChainlinkPriceFeed.scalePrice(weiPrice, 18, int32(uint32(priceDecimal)));
+    uint256 oriPrice = LibChainlinkPriceFeed.scalePrice(weiPrice, 18, priceDecimal);
     assertEq(oriPrice, price, "Incorrect price scaling");
 
     // RON/USD price
@@ -295,18 +295,18 @@ contract LibChainlinkPriceFeedTest is Test {
     priceDecimal = 8;
 
     // Case 1: priceDecimal == decimal
-    assertEq(price, LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 8), "Incorrect price scaling");
+    assertEq(price, LibChainlinkPriceFeed.scalePrice(price, priceDecimal, 8), "Incorrect price scaling");
 
     // Case 2: priceDecimal < decimal
-    weiPrice = LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 18);
+    weiPrice = LibChainlinkPriceFeed.scalePrice(price, priceDecimal, 18);
     assertEq(weiPrice, 776945610000000000, "Incorrect price scaling");
 
     // Case 3: priceDecimal > decimal
-    weiPrice2 = LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 6);
+    weiPrice2 = LibChainlinkPriceFeed.scalePrice(price, priceDecimal, 6);
     assertEq(weiPrice2, 776945, "Incorrect price scaling");
 
     // Case 4: reverse scaling
-    oriPrice = LibChainlinkPriceFeed.scalePrice(weiPrice, 18, int32(uint32(priceDecimal)));
+    oriPrice = LibChainlinkPriceFeed.scalePrice(weiPrice, 18, priceDecimal);
   }
 
   function testFuzz_ScalePrice_Calculate_Correctly(uint256 price, uint8 priceDecimal, uint8 decimal)
@@ -317,7 +317,7 @@ contract LibChainlinkPriceFeedTest is Test {
     safePrecision(uint256(price), decimal)
     safePrecision(uint256(price), priceDecimal)
   {
-    uint256 got = LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), int32(uint32(decimal)));
+    uint256 got = LibChainlinkPriceFeed.scalePrice(price, priceDecimal, decimal);
     console.log("Got", got);
     uint256 expected = uint256(scalePrice(price, priceDecimal, decimal));
     console.log("Expected", expected);
@@ -332,13 +332,5 @@ contract LibChainlinkPriceFeedTest is Test {
       return _price / uint256(10 ** uint256(_priceDecimals - _decimals));
     }
     return _price;
-  }
-
-  function latestRoundData()
-    public
-    pure
-    returns (uint80 roundId, uint256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
-  {
-    return (18446744073709553440, 8311679190297, 1742261649, 1742261667, 18446744073709553440);
   }
 }

--- a/test/price-feeds/LibChainlinkPriceFeed.t.sol
+++ b/test/price-feeds/LibChainlinkPriceFeed.t.sol
@@ -108,6 +108,29 @@ contract LibChainlinkPriceFeedTest is Test {
     _chainlinkAggregator[2021] = 0xBaA0AfA2f390349e0074bE787509a098e3044fc8;
   }
 
+  function testFuzz_inverseAndScalePrice(uint256 price, uint8 priceDecimal, uint8 scaleDecimal) external pure {
+    vm.assume(price != 0);
+    vm.assume(price <= uint256(type(int256).max));
+    vm.assume(priceDecimal <= 30);
+    vm.assume(scaleDecimal <= 30);
+
+    LibChainlinkPriceFeed.inverseAndScalePrice(price, priceDecimal, scaleDecimal);
+  }
+
+  function testFuzz_scalePrice(uint256 price, uint8 priceDecimal, uint8 scaleDecimal)
+    external
+    view
+    safePrecision(price, priceDecimal)
+    safePrecision(price, scaleDecimal)
+  {
+    vm.assume(price != 0);
+    vm.assume(price <= uint256(type(int256).max));
+    vm.assume(priceDecimal <= 30);
+    vm.assume(scaleDecimal <= 30);
+
+    LibChainlinkPriceFeed.scalePrice(price, priceDecimal, scaleDecimal);
+  }
+
   function testFork_Testnet_ConvertUSD2RON_Pyth_Vs_Chainlink() public {
     vm.selectFork(_testnetForkId);
 

--- a/test/price-feeds/LibChainlinkPriceFeed.t.sol
+++ b/test/price-feeds/LibChainlinkPriceFeed.t.sol
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { Test } from "../../dependencies/forge-std-1.8.2/src/Test.sol";
+import { VmSafe } from "../../dependencies/forge-std-1.8.2/src/Vm.sol";
+import { console } from "../../dependencies/forge-std-1.8.2/src/console.sol";
+import { ChainlinkPriceFeed, LibChainlinkPriceFeed } from "../../src/price-feeds/chainlink/LibChainlinkPriceFeed.sol";
+import { PythPriceFeed } from "../../src/price-feeds/pyth/LibPythPriceFeed.sol";
+import { AggregatorV2V3Interface } from
+  "../../dependencies/chainlink-2.21.0/contracts/src/v0.8/shared/interfaces/AggregatorV2V3Interface.sol";
+import { LibPowMath } from "../../src/math/LibPowMath.sol";
+import { Math } from "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/Math.sol";
+import { SafeMath } from "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/SafeMath.sol";
+import { SafeCast } from "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/SafeCast.sol";
+
+contract MockRONPriceFeed {
+  function latestAnswer() public pure returns (int256) {
+    return 77694561;
+  }
+
+  function latestRoundData()
+    public
+    pure
+    returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+  {
+    return (18446744073709555266, 77694561, 1742278624, 1742278642, 18446744073709555266);
+  }
+}
+
+contract PythPriceRONQuoterSample {
+  PythPriceFeed public ronPriceFeed;
+
+  function set(address aggregator, uint8 tokenInDecimal, uint8 tokenOutDecimal, bytes32 priceId) external {
+    ronPriceFeed.set(aggregator, tokenInDecimal, tokenOutDecimal, priceId, 1 days);
+  }
+
+  function convertTokenIn2TokenOut(uint256 tokenInWei) external view returns (uint256 tokenOutWei) {
+    tokenOutWei = ronPriceFeed.convertTokenIn2TokenOut(tokenInWei);
+  }
+
+  function convertTokenOut2TokenIn(uint256 tokenOutWei) external view returns (uint256 tokenInWei) {
+    tokenInWei = ronPriceFeed.convertTokenOut2TokenIn(tokenOutWei);
+  }
+}
+
+contract ChainlinkPriceRONQuoterSample {
+  ChainlinkPriceFeed public ronPriceFeed;
+
+  function set(address aggregator, int32 tokenInDecimal, int32 tokenOutDecimal) external {
+    ronPriceFeed.set(aggregator, tokenInDecimal, tokenOutDecimal);
+  }
+
+  function convertTokenIn2TokenOut(uint256 tokenInWei) external view returns (uint256 tokenOutWei) {
+    tokenOutWei = ronPriceFeed.convertTokenIn2TokenOut(tokenInWei);
+  }
+
+  function convertTokenOut2TokenIn(uint256 tokenOutWei) external view returns (uint256 tokenInWei) {
+    tokenInWei = ronPriceFeed.convertTokenOut2TokenIn(tokenOutWei);
+  }
+}
+
+contract LibChainlinkPriceFeedTest is Test {
+  using LibPowMath for *;
+  using Math for *;
+  using SafeCast for *;
+  using SafeMath for *;
+
+  uint8 _maxDecimal;
+  uint256 _mainnetForkId;
+  uint256 _testnetForkId;
+
+  mapping(uint256 chainId => bytes32 pythId) _pythPriceId;
+  mapping(uint256 chainId => address pyth) _pythAggregator;
+  mapping(uint256 chainid => address cl) _chainlinkAggregator;
+
+  modifier safeDecimal(uint8 decimal) {
+    vm.assume(decimal < _maxDecimal);
+    _;
+  }
+
+  modifier safePrecision(uint256 price, uint8 decimal) {
+    vm.assume(Math.log10(price) + decimal < _maxDecimal);
+    (bool ok,) = SafeMath.tryMul(price, 10 ** decimal);
+    vm.assume(ok);
+    _;
+  }
+
+  function setUp() public {
+    _maxDecimal = type(uint256).max.log10().toUint8();
+    console.log("Max decimal: %d", _maxDecimal);
+
+    _mainnetForkId = vm.createFork("ronin-mainnet", 43480534);
+    _testnetForkId = vm.createFork("ronin-testnet", 36183564);
+
+    _pythPriceId[2021] = 0x4cb9d530b042004b042e165ee0904b12fe534d40dac5fe1c71dfcdb522e6e3c2;
+    _pythPriceId[2020] = 0x97cfe19da9153ef7d647b011c5e355142280ddb16004378573e6494e499879f3;
+
+    _pythAggregator[2021] = 0xA2aa501b19aff244D90cc15a4Cf739D2725B5729;
+    _pythAggregator[2020] = 0x2880aB155794e7179c9eE2e38200202908C17B43;
+
+    _chainlinkAggregator[2020] = 0x0B6074F21488B95945989E513EFEA070096d931D;
+    _chainlinkAggregator[2021] = 0xBaA0AfA2f390349e0074bE787509a098e3044fc8;
+  }
+
+  function testFork_Testnet_ConvertUSD2RON_Pyth_Vs_Chainlink() public {
+    vm.selectFork(_testnetForkId);
+
+    PythPriceRONQuoterSample pythQuoter = new PythPriceRONQuoterSample();
+    pythQuoter.set(_pythAggregator[2021], 18, 6, _pythPriceId[2021]);
+
+    ChainlinkPriceRONQuoterSample chainlinkQuoter = new ChainlinkPriceRONQuoterSample();
+    chainlinkQuoter.set(_chainlinkAggregator[2021], 18, 6);
+
+    uint256 usdAmount = 150e6;
+    uint256 pythPrice = pythQuoter.convertTokenOut2TokenIn(usdAmount);
+    uint256 chainlinkPrice = chainlinkQuoter.convertTokenOut2TokenIn(usdAmount);
+
+    assertApproxEqRel(pythPrice, chainlinkPrice, 2e16, "Incorrect price conversion");
+  }
+
+  function testFork_Mainnet_ConvertUSD2RON_Pyth_Vs_Chainlink() public {
+    vm.selectFork(_mainnetForkId);
+
+    PythPriceRONQuoterSample pythQuoter = new PythPriceRONQuoterSample();
+    pythQuoter.set(_pythAggregator[2020], 18, 6, _pythPriceId[2020]);
+
+    ChainlinkPriceRONQuoterSample chainlinkQuoter = new ChainlinkPriceRONQuoterSample();
+    chainlinkQuoter.set(_chainlinkAggregator[2020], 18, 6);
+
+    uint256 usdAmount = 100e6;
+    uint256 pythPrice = pythQuoter.convertTokenOut2TokenIn(usdAmount);
+    uint256 chainlinkPrice = chainlinkQuoter.convertTokenOut2TokenIn(usdAmount);
+
+    assertApproxEqRel(pythPrice, chainlinkPrice, 1e16, "Incorrect price conversion");
+  }
+
+  function testFork_Testnet_ConvertRON2USD_Pyth_Vs_Chainlink() public {
+    vm.selectFork(_testnetForkId);
+
+    PythPriceRONQuoterSample pythQuoter = new PythPriceRONQuoterSample();
+    pythQuoter.set(_pythAggregator[2021], 18, 6, _pythPriceId[2021]);
+
+    ChainlinkPriceRONQuoterSample chainlinkQuoter = new ChainlinkPriceRONQuoterSample();
+    chainlinkQuoter.set(_chainlinkAggregator[2021], 18, 6);
+
+    uint256 ronAmount = 50e18;
+    uint256 pythPrice = pythQuoter.convertTokenIn2TokenOut(ronAmount);
+    uint256 chainlinkPrice = chainlinkQuoter.convertTokenIn2TokenOut(ronAmount);
+
+    assertApproxEqRel(pythPrice, chainlinkPrice, 2e16, "Incorrect price conversion");
+  }
+
+  function testFork_Mainnet_ConvertRON2USD_Pyth_Vs_Chainlink() public {
+    vm.selectFork(_mainnetForkId);
+
+    PythPriceRONQuoterSample pythQuoter = new PythPriceRONQuoterSample();
+    pythQuoter.set(_pythAggregator[2020], 18, 6, _pythPriceId[2020]);
+
+    ChainlinkPriceRONQuoterSample chainlinkQuoter = new ChainlinkPriceRONQuoterSample();
+    chainlinkQuoter.set(_chainlinkAggregator[2020], 18, 6);
+
+    uint256 ronAmount = 250e18;
+    uint256 pythPrice = pythQuoter.convertTokenIn2TokenOut(ronAmount);
+    uint256 chainlinkPrice = chainlinkQuoter.convertTokenIn2TokenOut(ronAmount);
+
+    assertApproxEqRel(pythPrice, chainlinkPrice, 1e16, "Incorrect price conversion");
+  }
+
+  function testConcrete_ConvertRON2USD() public {
+    ChainlinkPriceFeed memory converter = ChainlinkPriceFeed({
+      aggregator: AggregatorV2V3Interface(address(new MockRONPriceFeed())),
+      pairDecimal: 8,
+      tokenInDecimal: 18,
+      tokenOutDecimal: 18
+    });
+
+    uint256 ronAmount = 50e18;
+    uint256 ronPrice = LibChainlinkPriceFeed.convertTokenIn2TokenOut(converter, ronAmount);
+
+    assertEq(ronPrice, ronAmount * 77694561 / 1e8, "Incorrect price conversion");
+  }
+
+  function testConcrete_ConvertUSD2RON() public {
+    ChainlinkPriceFeed memory converter = ChainlinkPriceFeed({
+      aggregator: AggregatorV2V3Interface(address(new MockRONPriceFeed())),
+      pairDecimal: 8,
+      tokenInDecimal: 18,
+      tokenOutDecimal: 18
+    });
+
+    uint256 usdAmount = 100e18;
+    uint256 ronPrice = LibChainlinkPriceFeed.convertTokenOut2TokenIn(converter, usdAmount);
+
+    assertApproxEqAbs(ronPrice, 128709138339812487002, 100, "Incorrect price conversion");
+    assertApproxEqAbs(ronPrice, usdAmount * 1e8 / 77694561, 100, "Incorrect price conversion");
+  }
+
+  function testFuzz_Inverse_Calculate_Correctly(uint256 price, uint8 priceDecimal, uint8 decimal)
+    public
+    safeDecimal(priceDecimal)
+    safeDecimal(decimal)
+    safePrecision(uint256(price), decimal)
+    safePrecision(uint256(price), priceDecimal)
+  {
+    vm.assume(priceDecimal < 19);
+    vm.assume(decimal < 19);
+    vm.assume(price > 0);
+
+    uint256 got = LibChainlinkPriceFeed.inverse(int256(price), -int32(uint32(priceDecimal)), -int32(uint32(decimal)));
+
+    // Python script to calculate the expected value
+    // print('res:', int(1e{priceDecimal}/{price} * 10**{decimal}))
+    string[] memory cmd = new string[](3);
+    cmd[0] = "python";
+    cmd[1] = "-c";
+    cmd[2] = string.concat(
+      "print('res:',",
+      "int(1e",
+      vm.toString(priceDecimal),
+      "/",
+      vm.toString(price),
+      " * 10**",
+      vm.toString(decimal),
+      "))"
+    );
+
+    VmSafe.FfiResult memory ret = vm.tryFfi(cmd);
+    require(ret.exitCode == 0, string.concat("Python script failed. Reason: ", string(ret.stderr)));
+
+    string memory result = string(ret.stdout);
+    uint256 expected = vm.parseUint(vm.replace(result, "res: ", ""));
+
+    // allow max delta precision of of 5% 0-100% = [0, 1e18]
+    assertApproxEqRel(got, expected, 5e16, "Incorrect inverse price");
+  }
+
+  function testConcrete_Inverse() public pure {
+    // Case 0: priceExpo == expo
+    int256 price = 1e8;
+    int32 expo = -8;
+    uint256 weiPrice = LibChainlinkPriceFeed.inverse(price, expo, expo);
+    assertEq(weiPrice, 100000000, "Incorrect inverse price");
+
+    // Case 1: priceExpo > expo
+    // WBTC/USD price
+    price = 334172000;
+    expo = -8;
+    uint256 weiPrice2 = LibChainlinkPriceFeed.inverse(price, expo, -18);
+    assertEq(weiPrice2, 299247094310714242, "Incorrect inverse price");
+    assertApproxEqAbs(
+      LibChainlinkPriceFeed.inverse(int256(weiPrice2), -18, expo), uint256(price), 100, "Incorrect inverse price"
+    );
+
+    // Case 2: priceExpo < expo
+    // USDC/USD price
+    price = 99992523;
+    expo = -8;
+    uint256 weiPrice3 = LibChainlinkPriceFeed.inverse(price, expo, -6);
+    assertEq(weiPrice3, 1000074, "Incorrect inverse price");
+    assertApproxEqAbs(
+      LibChainlinkPriceFeed.inverse(int256(weiPrice3), -6, expo), uint256(price), 100, "Incorrect inverse price"
+    );
+  }
+
+  function testConcrete_ScalePrice_Calculate_Correctly() public pure {
+    // WBTC/USD price
+    uint256 price = 334172000;
+    uint8 priceDecimal = 8;
+
+    // Case 1: priceDecimal == decimal
+    assertEq(price, LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 8), "Incorrect price scaling");
+
+    // Case 2: priceDecimal < decimal
+    uint256 weiPrice = LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 18);
+    assertEq(weiPrice, 3341720000000000000, "Incorrect price scaling");
+
+    // Case 3: priceDecimal > decimal
+    uint256 weiPrice2 = LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 6);
+    assertEq(weiPrice2, 3341720, "Incorrect price scaling");
+
+    // Case 4: reverse scaling
+    uint256 oriPrice = LibChainlinkPriceFeed.scalePrice(weiPrice, 18, int32(uint32(priceDecimal)));
+    assertEq(oriPrice, price, "Incorrect price scaling");
+
+    // RON/USD price
+    price = 77694561;
+    priceDecimal = 8;
+
+    // Case 1: priceDecimal == decimal
+    assertEq(price, LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 8), "Incorrect price scaling");
+
+    // Case 2: priceDecimal < decimal
+    weiPrice = LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 18);
+    assertEq(weiPrice, 776945610000000000, "Incorrect price scaling");
+
+    // Case 3: priceDecimal > decimal
+    weiPrice2 = LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), 6);
+    assertEq(weiPrice2, 776945, "Incorrect price scaling");
+
+    // Case 4: reverse scaling
+    oriPrice = LibChainlinkPriceFeed.scalePrice(weiPrice, 18, int32(uint32(priceDecimal)));
+  }
+
+  function testFuzz_ScalePrice_Calculate_Correctly(uint256 price, uint8 priceDecimal, uint8 decimal)
+    public
+    view
+    safeDecimal(priceDecimal)
+    safeDecimal(decimal)
+    safePrecision(uint256(price), decimal)
+    safePrecision(uint256(price), priceDecimal)
+  {
+    uint256 got = LibChainlinkPriceFeed.scalePrice(price, int32(uint32(priceDecimal)), int32(uint32(decimal)));
+    console.log("Got", got);
+    uint256 expected = uint256(scalePrice(price, priceDecimal, decimal));
+    console.log("Expected", expected);
+
+    assertEq(got, expected, "Incorrect price scaling");
+  }
+
+  function scalePrice(uint256 _price, uint8 _priceDecimals, uint8 _decimals) internal pure returns (uint256) {
+    if (_priceDecimals < _decimals) {
+      return _price * uint256(10 ** uint256(_decimals - _priceDecimals));
+    } else if (_priceDecimals > _decimals) {
+      return _price / uint256(10 ** uint256(_priceDecimals - _decimals));
+    }
+    return _price;
+  }
+
+  function latestRoundData()
+    public
+    pure
+    returns (uint80 roundId, uint256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+  {
+    return (18446744073709553440, 8311679190297, 1742261649, 1742261667, 18446744073709553440);
+  }
+}

--- a/test/price-feeds/LibChainlinkPriceFeed.t.sol
+++ b/test/price-feeds/LibChainlinkPriceFeed.t.sol
@@ -14,6 +14,10 @@ import { SafeMath } from "../../dependencies/openzeppelin-4.9.6/contracts/utils/
 import { SafeCast } from "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/SafeCast.sol";
 
 contract MockRONPriceFeed {
+  function latestTimestamp() public pure returns (uint256) {
+    return 1742296233;
+  }
+
   function latestAnswer() public pure returns (int256) {
     return 77694561;
   }
@@ -47,7 +51,7 @@ contract ChainlinkPriceRONQuoterSample {
   ChainlinkPriceFeed public ronPriceFeed;
 
   function set(address aggregator, int32 tokenInDecimal, int32 tokenOutDecimal) external {
-    ronPriceFeed.set(aggregator, tokenInDecimal, tokenOutDecimal);
+    ronPriceFeed.set(aggregator, tokenInDecimal, tokenOutDecimal, 1 days);
   }
 
   function convertTokenIn2TokenOut(uint256 tokenInWei) external view returns (uint256 tokenOutWei) {
@@ -65,13 +69,13 @@ contract LibChainlinkPriceFeedTest is Test {
   using SafeCast for *;
   using SafeMath for *;
 
-  uint8 _maxDecimal;
-  uint256 _mainnetForkId;
-  uint256 _testnetForkId;
+  uint8 internal _maxDecimal;
+  uint256 internal _mainnetForkId;
+  uint256 internal _testnetForkId;
 
-  mapping(uint256 chainId => bytes32 pythId) _pythPriceId;
-  mapping(uint256 chainId => address pyth) _pythAggregator;
-  mapping(uint256 chainid => address cl) _chainlinkAggregator;
+  mapping(uint256 chainId => bytes32 pythId) internal _pythPriceId;
+  mapping(uint256 chainId => address pyth) internal _pythAggregator;
+  mapping(uint256 chainid => address cl) internal _chainlinkAggregator;
 
   modifier safeDecimal(uint8 decimal) {
     vm.assume(decimal < _maxDecimal);
@@ -87,6 +91,8 @@ contract LibChainlinkPriceFeedTest is Test {
 
   function setUp() public {
     _maxDecimal = type(uint256).max.log10().toUint8();
+    vm.warp(1742296320);
+
     console.log("Max decimal: %d", _maxDecimal);
 
     _mainnetForkId = vm.createFork("ronin-mainnet", 43480534);
@@ -171,7 +177,8 @@ contract LibChainlinkPriceFeedTest is Test {
       aggregator: AggregatorV2V3Interface(address(new MockRONPriceFeed())),
       pairDecimal: 8,
       tokenInDecimal: 18,
-      tokenOutDecimal: 18
+      tokenOutDecimal: 18,
+      maxAcceptableAge: 1 days
     });
 
     uint256 ronAmount = 50e18;
@@ -185,7 +192,8 @@ contract LibChainlinkPriceFeedTest is Test {
       aggregator: AggregatorV2V3Interface(address(new MockRONPriceFeed())),
       pairDecimal: 8,
       tokenInDecimal: 18,
-      tokenOutDecimal: 18
+      tokenOutDecimal: 18,
+      maxAcceptableAge: 1 days
     });
 
     uint256 usdAmount = 100e18;

--- a/test/price-feeds/LibChainlinkPriceFeed.t.sol
+++ b/test/price-feeds/LibChainlinkPriceFeed.t.sol
@@ -82,15 +82,24 @@ contract LibChainlinkPriceFeedTest is Test {
   mapping(uint256 chainid => address cl) internal _chainlinkAggregator;
 
   modifier safeDecimal(uint8 decimal) {
-    vm.assume(decimal < _maxDecimal);
+    _safeDecimal(decimal);
     _;
   }
 
+  function _safeDecimal(uint8 decimal) internal view {
+    vm.assume(decimal < _maxDecimal);
+  }
+
   modifier safePrecision(uint256 price, uint8 decimal) {
-    vm.assume(Math.log10(price) + decimal < _maxDecimal);
+    _safePrecision(price, decimal);
+    _;
+  }
+
+  function _safePrecision(uint256 price, uint8 decimal) internal view {
+    uint256 log10Price = Math.log10(price);
+    vm.assume(log10Price + decimal < _maxDecimal);
     (bool ok,) = SafeMath.tryMul(price, 10 ** decimal);
     vm.assume(ok);
-    _;
   }
 
   function setUp() public {
@@ -117,6 +126,7 @@ contract LibChainlinkPriceFeedTest is Test {
     vm.assume(price <= uint256(type(int256).max));
     vm.assume(priceDecimal <= 30);
     vm.assume(scaleDecimal <= 30);
+    vm.assume(Math.log10(price) < priceDecimal + scaleDecimal);
 
     LibChainlinkPriceFeed.inverseAndScalePrice(price, priceDecimal, scaleDecimal);
   }
@@ -131,6 +141,7 @@ contract LibChainlinkPriceFeedTest is Test {
     vm.assume(price <= uint256(type(int256).max));
     vm.assume(priceDecimal <= 30);
     vm.assume(scaleDecimal <= 30);
+    if (priceDecimal > scaleDecimal) vm.assume(Math.log10(price) >= priceDecimal - scaleDecimal);
 
     LibChainlinkPriceFeed.scalePrice(price, priceDecimal, scaleDecimal);
   }
@@ -238,6 +249,7 @@ contract LibChainlinkPriceFeedTest is Test {
     vm.assume(priceDecimal < 30);
     vm.assume(decimal < 30);
     vm.assume(price > 0);
+    vm.assume(Math.log10(price) < priceDecimal + decimal);
 
     uint256 got = LibChainlinkPriceFeed.inverseAndScalePrice(price, priceDecimal, decimal);
 
@@ -342,10 +354,10 @@ contract LibChainlinkPriceFeedTest is Test {
     safePrecision(uint256(price), decimal)
     safePrecision(uint256(price), priceDecimal)
   {
+    if (priceDecimal > decimal) vm.assume(Math.log10(price) >= priceDecimal - decimal);
+
     uint256 got = LibChainlinkPriceFeed.scalePrice(price, priceDecimal, decimal);
-    console.log("Got", got);
     uint256 expected = uint256(scalePrice(price, priceDecimal, decimal));
-    console.log("Expected", expected);
 
     assertEq(got, expected, "Incorrect price scaling");
   }

--- a/test/price-feeds/LibChainlinkPriceFeed.t.sol
+++ b/test/price-feeds/LibChainlinkPriceFeed.t.sol
@@ -14,6 +14,10 @@ import { SafeMath } from "../../dependencies/openzeppelin-4.9.6/contracts/utils/
 import { SafeCast } from "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/SafeCast.sol";
 
 contract MockRONPriceFeed {
+  function decimals() public pure returns (uint8) {
+    return 8;
+  }
+
   function latestTimestamp() public pure returns (uint256) {
     return 1742296233;
   }
@@ -198,7 +202,6 @@ contract LibChainlinkPriceFeedTest is Test {
   function testConcrete_ConvertRON2USD() public {
     ChainlinkPriceFeed memory converter = ChainlinkPriceFeed({
       _aggregator: AggregatorV2V3Interface(address(new MockRONPriceFeed())),
-      _pairDecimal: 8,
       _tokenInDecimal: 18,
       _tokenOutDecimal: 18,
       _maxAcceptableAge: 1 days
@@ -213,7 +216,6 @@ contract LibChainlinkPriceFeedTest is Test {
   function testConcrete_ConvertUSD2RON() public {
     ChainlinkPriceFeed memory converter = ChainlinkPriceFeed({
       _aggregator: AggregatorV2V3Interface(address(new MockRONPriceFeed())),
-      _pairDecimal: 8,
       _tokenInDecimal: 18,
       _tokenOutDecimal: 18,
       _maxAcceptableAge: 1 days

--- a/test/price-feeds/LibPythPriceFeed.t.sol
+++ b/test/price-feeds/LibPythPriceFeed.t.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { Test } from "../../dependencies/forge-std-1.8.2/src/Test.sol";
+import { PythStructs } from "../../dependencies/pyth-2.2.0/PythStructs.sol";
+import { LibPowMath } from "../../src/math/LibPowMath.sol";
+import "../../src/price-feeds/pyth/LibPythPriceFeed.sol";
+import "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/Math.sol";
+import "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/SignedMath.sol";
+import "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/SafeCast.sol";
+import "../../dependencies/openzeppelin-4.9.6/contracts/utils/math/SafeMath.sol";
+
+contract LibPythPriceFeedTest is Test {
+  using LibPythPriceFeed for PythStructs.Price;
+  using Math for *;
+  using SignedMath for *;
+  using SafeCast for *;
+  using SafeMath for *;
+
+  uint64 public constant MAX_PERCENTAGE = 100_00;
+  uint64 public constant EPS = 100;
+
+  bytes32 public constant RONUSD_ID = keccak256("RONUSD_ID");
+  bytes32 public constant USDRON_ID = keccak256("USDRON_ID");
+
+  uint8 internal _maxDecimals;
+  bytes32[] internal _pythIds;
+
+  modifier safeDecimals(uint8 decimals) {
+    vm.assume(decimals < 19);
+    _;
+  }
+
+  modifier safeWei(uint256 inpWei) {
+    vm.assume(Math.log10(inpWei) + Math.log10(getPrice(RONUSD_ID).price.toUint256() * 1e18) < _maxDecimals);
+    _;
+  }
+
+  modifier safeTokenAmount(uint256 amount, uint8 decimals) {
+    (bool ok,) = amount.tryMul(10 ** decimals);
+    vm.assume(ok);
+    _;
+  }
+
+  function setUp() public {
+    _maxDecimals = Math.log10(type(uint256).max).toUint8();
+    _pythIds.push(RONUSD_ID);
+    _pythIds.push(USDRON_ID);
+  }
+
+  function testFuzz_Convert_RONWeiToUSDWei(uint256 inpWei, uint8 outDecimals)
+    public
+    safeWei(inpWei)
+    safeDecimals(outDecimals)
+    returns (uint256 calc)
+  {
+    PythStructs.Price memory out = getPrice(RONUSD_ID);
+    calc = out.inverse(-18).mul({ inpWei: inpWei, inpDecimals: 18, outDecimals: int32(uint32(outDecimals)) });
+    uint256 expt =
+      inpWei.mulDiv(LibPowMath.exp10(1, int32(uint32(outDecimals)) - out.expo) / out.price.toUint256(), 1e18);
+    assertEq(calc, expt);
+  }
+
+  function testConcrete_Convert_RONWeiToUSDWei() public {
+    assertEq(testFuzz_Convert_RONWeiToUSDWei(1e18, 8), 206943385);
+    assertEq(testFuzz_Convert_RONWeiToUSDWei(2e18, 9), 4138867702);
+    assertEq(testFuzz_Convert_RONWeiToUSDWei(4e18, 10), 82777354060);
+  }
+
+  function testFuzz_Convert_USDWeiToRONWei(uint256 inpWei, uint8 usdDecimals)
+    public
+    safeDecimals(usdDecimals)
+    safeWei(inpWei)
+    returns (uint256 calc)
+  {
+    uint256 inpMask = LibPowMath.exp10(1, int32(uint32(usdDecimals)));
+
+    PythStructs.Price memory out = getPrice(RONUSD_ID);
+    calc = out.mul({ inpWei: inpWei, inpDecimals: int32(uint32(usdDecimals)), outDecimals: 18 });
+    uint256 expt = inpWei.mulDiv(LibPowMath.exp10(out.price.toUint256(), 18 + out.expo), inpMask);
+    assertEq(calc, expt);
+  }
+
+  function testFuzz_Convert_USDAmountToRONWei(uint256 usd, uint8 usdDecimals)
+    public
+    safeDecimals(usdDecimals)
+    safeTokenAmount(usd, usdDecimals)
+    returns (uint256 calc)
+  {
+    return testFuzz_Convert_USDWeiToRONWei(usd * 10 ** usdDecimals, usdDecimals);
+  }
+
+  function testFuzz_Convert_USDAmountToRONWei(uint8 decimals) public safeDecimals(decimals) {
+    assertEq(testFuzz_Convert_USDAmountToRONWei(1, decimals), 483223950000000000);
+    assertEq(testFuzz_Convert_USDAmountToRONWei(2, decimals), 966447900000000000);
+    assertEq(testFuzz_Convert_USDAmountToRONWei(4, decimals), 1932895800000000000);
+    assertEq(testFuzz_Convert_USDAmountToRONWei(8, decimals), 3865791600000000000);
+    assertEq(testFuzz_Convert_USDAmountToRONWei(16, decimals), 7731583200000000000);
+    assertEq(testFuzz_Convert_USDAmountToRONWei(32, decimals), 15463166400000000000);
+  }
+
+  function testConcrete_Convert_USDWeiToRONWei() public {
+    assertEq(testFuzz_Convert_USDWeiToRONWei(100000000, 8), 483223950000000000);
+    assertEq(testFuzz_Convert_USDWeiToRONWei(200000000, 8), 966447900000000000);
+    assertEq(testFuzz_Convert_USDWeiToRONWei(400000000, 8), 1932895800000000000);
+    assertEq(testFuzz_Convert_USDWeiToRONWei(800000000, 8), 3865791600000000000);
+    assertEq(testFuzz_Convert_USDWeiToRONWei(1600000000, 8), 7731583200000000000);
+    assertEq(testFuzz_Convert_USDWeiToRONWei(3200000000, 8), 15463166400000000000);
+
+    assertEq(testFuzz_Convert_USDWeiToRONWei(1000000000000000000, 18), 483223950000000000);
+    assertEq(testFuzz_Convert_USDWeiToRONWei(2000000000000000000, 18), 966447900000000000);
+    assertEq(testFuzz_Convert_USDWeiToRONWei(4000000000000000000, 18), 1932895800000000000);
+    assertEq(testFuzz_Convert_USDWeiToRONWei(8000000000000000000, 18), 3865791600000000000);
+    assertEq(testFuzz_Convert_USDWeiToRONWei(16000000000000000000, 18), 7731583200000000000);
+    assertEq(testFuzz_Convert_USDWeiToRONWei(32000000000000000000, 18), 15463166400000000000);
+  }
+
+  function testFuzz_Inverse(uint8 idIdx, uint8 inverseTimes) public {
+    vm.assume(inverseTimes > 0);
+    uint256 inpIdx = idIdx % _pythIds.length;
+    uint256 outIdx = (uint256(idIdx) + inverseTimes) % _pythIds.length;
+
+    PythStructs.Price memory pythOutput = getPrice(_pythIds[inpIdx]);
+    for (uint256 i = 0; i < inverseTimes; i++) {
+      pythOutput = pythOutput.inverse({ expo: -8 });
+    }
+
+    assertEq(pythOutput.price, getPrice(_pythIds[outIdx]).price);
+  }
+
+  function testConcrete_Inverse() public {
+    assertEq(getPrice(RONUSD_ID).price, getPrice(USDRON_ID).inverse({ expo: -8 }).price);
+    assertEq(getPrice(USDRON_ID).price, getPrice(RONUSD_ID).inverse({ expo: -8 }).price);
+  }
+
+  function getPrice(bytes32 id) public pure returns (PythStructs.Price memory) {
+    if (id == RONUSD_ID) return PythStructs.Price({ price: 48322395, conf: 116535, expo: -8, publishTime: 0 });
+    if (id == USDRON_ID) return PythStructs.Price({ price: 206943385, conf: 116535, expo: -8, publishTime: 0 });
+    return PythStructs.Price({ price: 0, conf: 0, expo: 0, publishTime: 0 });
+  }
+}

--- a/test/price-feeds/LibPythPriceFeed.t.sol
+++ b/test/price-feeds/LibPythPriceFeed.t.sol
@@ -50,6 +50,7 @@ contract LibPythPriceFeedTest is Test {
 
   function testFuzz_Convert_RONWeiToUSDWei(uint256 inpWei, uint8 outDecimals)
     public
+    view
     safeWei(inpWei)
     safeDecimals(outDecimals)
     returns (uint256 calc)
@@ -61,7 +62,7 @@ contract LibPythPriceFeedTest is Test {
     assertEq(calc, expt);
   }
 
-  function testConcrete_Convert_RONWeiToUSDWei() public {
+  function testConcrete_Convert_RONWeiToUSDWei() public view {
     assertEq(testFuzz_Convert_RONWeiToUSDWei(1e18, 8), 206943385);
     assertEq(testFuzz_Convert_RONWeiToUSDWei(2e18, 9), 4138867702);
     assertEq(testFuzz_Convert_RONWeiToUSDWei(4e18, 10), 82777354060);
@@ -69,6 +70,7 @@ contract LibPythPriceFeedTest is Test {
 
   function testFuzz_Convert_USDWeiToRONWei(uint256 inpWei, uint8 usdDecimals)
     public
+    view
     safeDecimals(usdDecimals)
     safeWei(inpWei)
     returns (uint256 calc)
@@ -83,6 +85,7 @@ contract LibPythPriceFeedTest is Test {
 
   function testFuzz_Convert_USDAmountToRONWei(uint256 usd, uint8 usdDecimals)
     public
+    view
     safeDecimals(usdDecimals)
     safeTokenAmount(usd, usdDecimals)
     returns (uint256 calc)
@@ -90,7 +93,7 @@ contract LibPythPriceFeedTest is Test {
     return testFuzz_Convert_USDWeiToRONWei(usd * 10 ** usdDecimals, usdDecimals);
   }
 
-  function testFuzz_Convert_USDAmountToRONWei(uint8 decimals) public safeDecimals(decimals) {
+  function testFuzz_Convert_USDAmountToRONWei(uint8 decimals) public view safeDecimals(decimals) {
     assertEq(testFuzz_Convert_USDAmountToRONWei(1, decimals), 483223950000000000);
     assertEq(testFuzz_Convert_USDAmountToRONWei(2, decimals), 966447900000000000);
     assertEq(testFuzz_Convert_USDAmountToRONWei(4, decimals), 1932895800000000000);
@@ -99,7 +102,7 @@ contract LibPythPriceFeedTest is Test {
     assertEq(testFuzz_Convert_USDAmountToRONWei(32, decimals), 15463166400000000000);
   }
 
-  function testConcrete_Convert_USDWeiToRONWei() public {
+  function testConcrete_Convert_USDWeiToRONWei() public view {
     assertEq(testFuzz_Convert_USDWeiToRONWei(100000000, 8), 483223950000000000);
     assertEq(testFuzz_Convert_USDWeiToRONWei(200000000, 8), 966447900000000000);
     assertEq(testFuzz_Convert_USDWeiToRONWei(400000000, 8), 1932895800000000000);
@@ -115,7 +118,7 @@ contract LibPythPriceFeedTest is Test {
     assertEq(testFuzz_Convert_USDWeiToRONWei(32000000000000000000, 18), 15463166400000000000);
   }
 
-  function testFuzz_Inverse(uint8 idIdx, uint8 inverseTimes) public {
+  function testFuzz_Inverse(uint8 idIdx, uint8 inverseTimes) public view {
     vm.assume(inverseTimes > 0);
     uint256 inpIdx = idIdx % _pythIds.length;
     uint256 outIdx = (uint256(idIdx) + inverseTimes) % _pythIds.length;
@@ -128,7 +131,7 @@ contract LibPythPriceFeedTest is Test {
     assertEq(pythOutput.price, getPrice(_pythIds[outIdx]).price);
   }
 
-  function testConcrete_Inverse() public {
+  function testConcrete_Inverse() public pure {
     assertEq(getPrice(RONUSD_ID).price, getPrice(USDRON_ID).inverse({ expo: -8 }).price);
     assertEq(getPrice(USDRON_ID).price, getPrice(RONUSD_ID).inverse({ expo: -8 }).price);
   }

--- a/test/transfers/LibNativeTransfer.t.sol
+++ b/test/transfers/LibNativeTransfer.t.sol
@@ -25,9 +25,12 @@ contract LibNativeTransferTest is Test {
     // Transferring to msg.sender can fail because it's possible to overflow their ETH balance as it begins non-zero.
     if (recipient.code.length > 0 || uint256(uint160(recipient)) <= 18 || recipient == msg.sender) return;
 
+    uint256 recipientBalanceBefore = recipient.balance;
     amount = _bound(amount, 0, address(this).balance);
     LibNativeTransfer.transfer(recipient, amount, gas);
 
-    assertEq(recipient.balance, amount);
+    uint256 recipientBalanceAfter = recipient.balance;
+
+    assertEq(recipientBalanceAfter - recipientBalanceBefore, amount);
   }
 }


### PR DESCRIPTION
This pull request introduces several updates and new features to the project, particularly focusing on dependency management, price feed integration, and mathematical utility functions. Key changes include the addition of new dependencies, updates to existing dependencies, and the implementation of new libraries and contracts for handling price feeds and mathematical operations.

Dependency updates and additions:

* Updated the `ronin-mainnet` RPC endpoint in `foundry.toml` to use the archived endpoint.
* Added new dependencies for `chainlink`, `openzeppelin`, and `pyth` in `foundry.toml`.
* Removed old remappings and added new remappings for the updated dependencies in `remappings.txt`.

Price feed integration:

* Implemented `ChainlinkPriceFeedConsumer` contract for managing Chainlink price feeds, including methods for updating and retrieving price feed data.
* Added `LibChainlinkPriceFeed` library for handling Chainlink price feed operations, including setting up price feeds and converting token amounts.
* Introduced `LibPythPriceFeed` library for managing Pyth price feeds, including methods for converting token amounts and handling price updates.

Mathematical utilities:

* Added `LibPowMath` library for performing advanced mathematical operations, such as exponentiation and precise multiplication and division.

Dependency path updates:

* Updated import paths in `RONTransferHelper.sol`, `TransferFromHelper.sol`, and `TransferHelper.sol` to reflect the new dependency structure. [[1]](diffhunk://#diff-8a2d3c867fcf4d0a7fd448dbfa3523183571f6ddad06c343319b060d8d99f9c0L4-R4) [[2]](diffhunk://#diff-a8199f20357cb224ca7ac59dea9b22d31c6f07b3c1accaca33bd5a493f6330d3L4-R4) [[3]](diffhunk://#diff-8115cabcbf9af3c3760f5c644ee9a0d1a0d73eaf377b727bb485aef4356a29a4L4-R4)