### PR TITLE
feat: add lib randomizer

### DIFF
--- a/src/utils/LibRandomizer.sol
+++ b/src/utils/LibRandomizer.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library LibRandomizer {
+  error ErrCeilingNotHigherThanFloor(uint256 floor, uint256 ceiling);
+
+  /**
+   * @dev Returns a random value in range [0, upper)
+   */
+  function random(uint256 upper, uint256[1] memory seed) internal pure returns (uint256 result) {
+    result = seed[0] % upper;
+    seed[0] = uint256(keccak256(abi.encodePacked(seed[0])));
+  }
+
+  /**
+   * @dev Returns a random value in range [floor, ceiling], i.e the range is inclusive.
+   * When floor == ceiling = `x`, the random result always be equal to `x`.
+   */
+  function randomRange(uint256 floor, uint256 ceiling, uint256[1] memory seed) internal pure returns (uint256) {
+    if (floor > ceiling) revert ErrCeilingNotHigherThanFloor(floor, ceiling);
+    return floor + random(ceiling - floor + 1, seed);
+  }
+}


### PR DESCRIPTION
### Description
This pull request introduces a new utility library, `LibRandomizer`, to provide reusable random number generation functionality in Solidity. The library includes methods for generating random numbers within specified ranges and handles edge cases with appropriate error handling.

### New utility library for random number generation:

* `src/utils/LibRandomizer.sol`: Added a new library `LibRandomizer` with two functions:
  - `random`: Generates a random number in the range `[0, upper)`.
  - [`randomRange`](diffhunk://#diff-d26b67bb11e857fc5f27cbaa275c33c1ab027ebc0feb3bdee7e41272a61ec7bcR1-R23): Generates a random number in the inclusive range `[floor, ceiling]`, with validation to ensure `floor <= ceiling`. An error `ErrCeilingNotHigherThanFloor` is thrown if the range is invalid.
### Checklist

-   [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
-   [x] The box that allows repo maintainers to update this PR is checked
-   [x] I tested locally to make sure this feature/fix works
